### PR TITLE
[FE] 로그인 페이지 유효성 검사 추가, CSS 재작업

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,18 @@
+export async function login(email: string, password: string): Promise<any> {
+  const response = await fetch('/api/auth/user/signin', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('login fail');
+  }
+  const result = response.json();
+  return result;
+}

--- a/frontend/src/components/input/input.css
+++ b/frontend/src/components/input/input.css
@@ -29,5 +29,5 @@
 
 .input__border {
   transition: all 0.2s ease-in-out;
-  @apply border-b-sm border-text-primary;
+  @apply border-b-sm border-text-primary mb-4;
 }

--- a/frontend/src/components/input/input.tsx
+++ b/frontend/src/components/input/input.tsx
@@ -1,8 +1,10 @@
 interface InputProps<State> {
-  type: React.HTMLInputTypeAttribute
-  placeholder?: string
-  setValue: React.Dispatch<React.SetStateAction<State>>
-  icon?: React.ReactNode
+  type: React.HTMLInputTypeAttribute;
+  label: string;
+  placeholder?: string;
+  setValue: React.Dispatch<React.SetStateAction<State>>;
+  icon?: React.ReactNode;
+  onBlur?: () => void;
 }
 
 /**
@@ -10,21 +12,35 @@ interface InputProps<State> {
  * @params setValue 외부에서 상태를 관리하기 위한 setState 함수
  * @params icon 아이콘을 보낼 수 있음
  */
-const Input = <State,>({ type, setValue, placeholder, icon }: InputProps<State>) => {
+const Input = <State,>({
+  type,
+  setValue,
+  label,
+  placeholder,
+  icon,
+  onBlur,
+}: InputProps<State>) => {
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.currentTarget
-    setValue(value as State)
-  }
+    const { value } = event.currentTarget;
+    setValue(value as State);
+  };
 
   return (
-    <div className="input__wrapper">
-      <div className="input__icon_wrapper">
+    <label className='input__wrapper'>
+      <span className='display-regular-14 mb-2'>{label}</span>
+      <div className='input__icon_wrapper'>
         {icon && icon}
-        <input type={type} className="input" placeholder={placeholder} onChange={handleOnChange} />
+        <input
+          type={type}
+          className='input'
+          placeholder={placeholder}
+          onChange={handleOnChange}
+          onBlur={onBlur}
+        />
       </div>
-      <div className="input__border" />
-    </div>
-  )
-}
+      <div className='input__border' />
+    </label>
+  );
+};
 
-export default Input
+export default Input;

--- a/frontend/src/pages/auth/signin/SigninFooter.tsx
+++ b/frontend/src/pages/auth/signin/SigninFooter.tsx
@@ -1,10 +1,12 @@
+import { Link } from 'react-router-dom';
+
 export default function SigninFooter() {
   return (
-    <div className='flex justify-center align-center gap-xs p-sm m-xs border border-text-secondary'>
+    <div className='flex justify-center align-center gap-xs p-[2rem] border display-regular-14'>
       <span>계정이 없으신가요? </span>
-      <a className='text-green-700' href='/auth/signup'>
+      <Link className='text-green-700 text-point-blue ml-2' to='/auth/signup'>
         회원가입
-      </a>
+      </Link>
     </div>
   );
 }

--- a/frontend/src/pages/auth/signin/SigninForm.tsx
+++ b/frontend/src/pages/auth/signin/SigninForm.tsx
@@ -1,49 +1,80 @@
 import { useState } from 'react';
+import { login } from '../../../api/auth';
+import { useNavigate } from 'react-router-dom';
+import Input from '../../../components/input/input';
+import SubmitButton from '../../../components/button/submitButton';
+
+const emailRegex = new RegExp('[a-z0-9]+@[a-z]+.[a-z]{2,3}');
 
 export default function SigninForm() {
-  const [emailAddress, setEmailAddress] = useState('');
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState(false);
   const [password, setPassword] = useState('');
+  const [passwordError, setPasswordError] = useState(false);
+  const [loginError, setLoginError] = useState(false);
+  const navigate = useNavigate();
 
-  const handleEmailAddress = (e: React.ChangeEvent<HTMLInputElement>) =>
-    setEmailAddress(e.target.value);
-
-  const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) =>
-    setPassword(e.target.value);
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (emailError || passwordError) {
+      return;
+    }
+    try {
+      await login(email, password);
+      navigate('/');
+    } catch (error) {
+      setPassword('');
+      setLoginError(true);
+    }
+  };
+
+  const handleBlurEmail = () => {
+    const isCorrectEmailFormat = emailRegex.test(email);
+    setEmailError(!isCorrectEmailFormat);
+    setLoginError(false);
+  };
+
+  const handleBlurPassword = () => {
+    const isCorrectPasswordLength =
+      password.length >= 4 && password.length <= 20;
+    setPasswordError(!isCorrectPasswordLength);
+    setLoginError(false);
   };
 
   return (
     <form
       onSubmit={handleSubmit}
-      className='flex flex-col p-md m-sm gap-sm border'
+      className='flex flex-col p-[3rem] mb-4 gap-sm border'
     >
-      <label className='flex flex-col'>
-        <span>이메일</span>
-        <input
-          className='flex-1 mt-2 bg-gray-100 p-xs rounded'
-          value={emailAddress}
-          type='email'
-          placeholder='abc@email.com'
-          onChange={handleEmailAddress}
-        />
-      </label>
-      <label className='flex flex-col'>
-        <span>비밀번호</span>
-        <input
-          className='flex-1 mt-2 bg-gray-100 p-xs rounded'
-          value={password}
-          type='password'
-          onChange={handlePassword}
-        />
-      </label>
-      <button
-        className='text-white font-bold bg-point-green p-sm rounded'
-        type='submit'
-      >
-        로그인
-      </button>
+      <Input
+        label='이메일'
+        type='email'
+        setValue={setEmail}
+        placeholder='fancamp@naver.com'
+        onBlur={handleBlurEmail}
+      />
+      {emailError && (
+        <div className='display-regular-14 text-error mb-4'>
+          이메일의 형식이 맞지 않아요!
+        </div>
+      )}
+      <Input
+        label='비밀번호'
+        type='password'
+        setValue={setPassword}
+        onBlur={handleBlurPassword}
+      />
+      {passwordError && (
+        <div className='display-regular-14 text-error mb-4'>
+          비밀번호의 글자 수는 4~20 사이여야 합니다!
+        </div>
+      )}
+      <SubmitButton text='로그인' />
+      {loginError && (
+        <div className='display-regular-14 text-error mt-4'>
+          로그인에 실패했습니다!
+        </div>
+      )}
     </form>
   );
 }

--- a/frontend/src/pages/auth/signin/index.tsx
+++ b/frontend/src/pages/auth/signin/index.tsx
@@ -3,9 +3,9 @@ import SigninFooter from './SigninFooter';
 
 export default function SigninPage() {
   return (
-    <>
+    <div className='w-[500px] h-[600px] p-8'>
       <SigninForm />
       <SigninFooter />
-    </>
+    </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,7 +15,11 @@ export default {
       },
     },
     spacing: {
-      xs: '0.25rem', // 5px
+      2: '0.5rem',
+      4: '1rem',
+      8: '2rem',
+      24: '6rem',
+      xs: '0.25rem', // 4px
       sm: '0.5rem', // 8px
       md: '1rem', // 16px
       lg: '1.5rem', // 24px
@@ -31,7 +35,8 @@ export default {
       'point-lavender': '#D4AAFF',
       transparent: 'transparent',
       'surface-primary': '#FFFFFF',
+      error: '#ff4d4d',
     },
   },
   plugins: [],
-}
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,19 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import svgr from 'vite-plugin-svgr'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react(), svgr()],
-})
+  plugins: [react(), svgr()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://223.130.146.223:3000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        secure: false,
+        ws: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- [BGP-84]

### 변경 사항
- input 컴포넌트 Form에 onBlur props 추가
- proxy api Vite환경 설정에 추가
- login 함수 api/auth.ts로 분리
- 추가 된 테일윈드 css 프리셋에 맞게 CSS 수정
- 이메일, 비밀번호 유효성 추가, 맞지 않을 시 오류 출력
- 로그인 실패시 에러 추가

### 동작 확인
![1](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/702abe27-0fc9-4067-8801-4860ab08b227)
- 이메일 형식 정규표현식으로 확인 후 틀리다면 에러 메세지
- 비밀번호 길이 4~20 사이인지 확인 후 틀리다면 에러 메세지

![2](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/b2fc7481-0a02-4381-aa61-4cd2920a25a8)
- 로그인 실패시 에러 메세지

[BGP-84]: https://coli-heo.atlassian.net/browse/BGP-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ