### PR TITLE
[FE] AuthContext 구현

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,46 +1,62 @@
 module.exports = {
   root: true,
   env: { browser: true, es2021: true },
-  extends: ['airbnb', 'airbnb-typescript', 'airbnb/hooks', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended','plugin:prettier/recommended'],
+  extends: [
+    'airbnb',
+    'airbnb-typescript',
+    'airbnb/hooks',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
     project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
   },
   plugins: ['react', '@typescript-eslint', 'prettier'],
   rules: {
-    'react/jsx-props-no-spreading':['off'],
-    'import/extensions': [ 'error', 'ignorePackages', { 'js': 'never', 'jsx': 'never', 'ts': 'never', 'tsx': 'never' } ],
+    'react/jsx-props-no-spreading': ['off'],
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      { js: 'never', jsx: 'never', ts: 'never', tsx: 'never' },
+    ],
     'react/react-in-jsx-scope': 'off',
-    'import/extensions': ['error', 'ignorePackages', {
-      'js': 'never',
-      'jsx': 'never',
-      'ts': 'never',
-      'tsx': 'never'
-    }],
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
     'import/no-unresolved': 'off',
-    'import/no-extraneous-dependencies':'off',
-    'prettier/prettier':[
+    'import/no-extraneous-dependencies': 'off',
+    'prettier/prettier': [
       'error',
       {
-        endOfLine: 'auto'
-      }
+        endOfLine: 'auto',
+      },
     ],
     'no-use-before-define': [
       'error',
       {
-          'functions': false,
-          'classes': false,
-          'variables': false
-      }
+        functions: false,
+        classes: false,
+        variables: false,
+      },
     ],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     'react/require-default-props': 'off',
     'react-hooks/exhaustive-deps': 'off',
-    'import/prefer-default-export': 'off'
+    'import/prefer-default-export': 'off',
   },
-}
+};

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,7 @@
-export async function login(email: string, password: string): Promise<any> {
-  const response = await fetch('/api/auth/user/signin', {
+import { Auth } from '../types/api/auth';
+
+export async function signin(email: string, password: string): Promise<Auth> {
+  const response = await fetch('/api/auth/users/signin', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -20,9 +22,9 @@ export async function login(email: string, password: string): Promise<any> {
 export async function signup(
   email: string,
   password: string,
-  username: string,
-): Promise<any> {
-  const response = await fetch('/api/auth/user', {
+  chatname: string
+): Promise<Auth> {
+  const response = await fetch('/api/auth/users', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -30,7 +32,7 @@ export async function signup(
     body: JSON.stringify({
       email,
       password,
-      username,
+      chatname,
       profileImage: '',
       isMaster: true,
     }),
@@ -38,6 +40,18 @@ export async function signup(
   });
   if (!response.ok) {
     throw new Error('회원가입 실패');
+  }
+  const result = response.json();
+  return result;
+}
+
+export async function isValidSession(): Promise<Auth> {
+  const response = await fetch('/api/auth/users', {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('유효한 세션이 아닙니다');
   }
   const result = response.json();
   return result;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useEffect, useState } from 'react';
+import { isValidSession } from '../api/auth';
+import { Auth } from '../types/api/auth';
+
+interface AuthContextType {
+  auth: Auth | null;
+  setAuth: React.Dispatch<React.SetStateAction<Auth | null>>;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [auth, setAuth] = useState<Auth | null>(null);
+
+  useEffect(() => {
+    const isSignedIn = localStorage.getItem('isSignedIn');
+    const refreshAuth = async () => {
+      try {
+        const result = await isValidSession();
+        setAuth(result);
+      } catch (error) {
+        localStorage.setItem('isSignedIn', 'false');
+      }
+    };
+
+    if (isSignedIn === 'true' && auth === null) {
+      refreshAuth();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (auth) {
+      localStorage.setItem('isSignedIn', 'true');
+      return;
+    }
+
+    localStorage.setItem('isSignedIn', 'false');
+  }, [auth]);
+
+  return (
+    <AuthContext.Provider value={{ auth, setAuth }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export default AuthContext;

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import AuthContext from '../contexts/AuthContext';
+
+export default function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('AuthProvider not found.');
+  }
+
+  return context;
+}

--- a/frontend/src/types/api/auth.d.ts
+++ b/frontend/src/types/api/auth.d.ts
@@ -1,0 +1,5 @@
+export type Auth = {
+  email: string;
+  publicId: string;
+  isMaster: boolean;
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- [BGP-129]

### 변경 사항
- Parsing error: Cannot read file '...path\tsconfig.json' 에러 해결하기 위해 eslintrc.cjs 수정 
- tsconfigRootDir: __dirname

```javascript
parserOptions: {
    ...prev,
    tsconfigRootDir: __dirname,
  },
```

#### contexts/AuthContext.tsx

```javascript
export function AuthProvider({ children }: { children: React.ReactNode }) {
  const [auth, setAuth] = useState<Auth | null>(null);

// 새로고침 시에 서버에 api 요청하여 세션이 유효한지 확인 후에 다시 setAuth 
  useEffect(() => {
    const isSignedIn = localStorage.getItem('isSignedIn');
    const refreshAuth = async () => {
      try {
        const result = await isValidSession();
        setAuth(result);
      } catch (error) {
        localStorage.setItem('isSignedIn', 'false');
      }
    };

    if (isSignedIn === 'true' && auth === null) {
      refreshAuth();
    }
  }, []);

// auth가 유효하면 로컬 스토리지에 isSignedIn 저장
  useEffect(() => {
    if (auth) {
      localStorage.setItem('isSignedIn', 'true');
      return;
    }

    localStorage.setItem('isSignedIn', 'false');
  }, [auth]);

  return (
    <AuthContext.Provider value={{ auth, setAuth }}>
      {children}
    </AuthContext.Provider>
  );
}
```


### 동작 확인
- 아직 로그인 폼과 회원가입 폼의 코드 수정은 안 이뤄졌지만 적용시 잘 동작하는 것을 확인했고 라우팅 구현시에 폼의 수정도 이뤄질 예정입니다.

[BGP-129]: https://coli-heo.atlassian.net/browse/BGP-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ