### PR TITLE
[FE] AuthContext 수정, 로그인 페이지, 회원가입 페이지 리다이렉트, 로그아웃 버튼 추가

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -56,3 +56,13 @@ export async function isValidSession(): Promise<Auth> {
   const result = response.json();
   return result;
 }
+
+export async function signout(): Promise<any> {
+  const response = await fetch('/api/auth/users/signout', {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('로그아웃 실패');
+  }
+}

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
-import SideMenu from '../components/menu/sideMenu';
+import SideMenu from '../menu/sideMenu';
 
-function Root() {
+export default function Layout() {
   return (
     <main className="relative flex w-[67.5rem] justify-between h-center">
       <SideMenu />
@@ -11,5 +11,3 @@ function Root() {
     </main>
   );
 }
-
-export default Root;

--- a/frontend/src/components/menu/sideMenu.tsx
+++ b/frontend/src/components/menu/sideMenu.tsx
@@ -1,5 +1,5 @@
 import useAuth from '../../hooks/useAuth';
-import { Link, NavLink, useLocation } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import { signout } from '../../api/auth';
 
 const mainMenu = [
@@ -18,7 +18,6 @@ const secondaryMenu = [
 
 export default function SideMenu() {
   const { auth } = useAuth();
-  const location = useLocation();
 
   const authMenu = [
     { to: '/auth/signin', text: '로그인' },
@@ -26,7 +25,7 @@ export default function SideMenu() {
   ];
 
   const handleSignout = async () => {
-    const result = await signout();
+    await signout();
     window.location.reload();
   };
 

--- a/frontend/src/components/menu/sideMenu.tsx
+++ b/frontend/src/components/menu/sideMenu.tsx
@@ -1,14 +1,34 @@
-import { Link, useLocation } from 'react-router-dom';
-import Text from '../text/text';
+import useAuth from '../../hooks/useAuth';
+import { Link, NavLink, useLocation } from 'react-router-dom';
+import { signout } from '../../api/auth';
 
-interface SideMenuLinkProps {
-  to: string;
-  text: string;
-  currentPath: string;
-}
+const mainMenu = [
+  { to: '/', text: 'Home' },
+  { to: '/search', text: 'Search' },
+  { to: '/explore', text: 'Explore' },
+];
 
-function SideMenu() {
+const secondaryMenu = [
+  { to: '/camps/0b5060ce-dfb4-4497-b0bf-34c6b7fce368/post', text: '캠프' },
+  { to: '/camps/0b5060ce-dfb4-4497-b0bf-34c6b7fce368/chat', text: '> 채팅' },
+  { to: '/camps/0b5060ce-dfb4-4497-b0bf-34c6b7fce368/post', text: '> 포스트' },
+  { to: '/demo/components', text: '컴포넌트 데모' },
+  { to: '/demo/api/rest', text: 'Mock Api' },
+];
+
+export default function SideMenu() {
+  const { auth } = useAuth();
   const location = useLocation();
+
+  const authMenu = [
+    { to: '/auth/signin', text: '로그인' },
+    { to: '/auth/signup', text: '회원가입' },
+  ];
+
+  const handleSignout = async () => {
+    const result = await signout();
+    window.location.reload();
+  };
 
   return (
     <div className="sticky left-[0] top-[0] z-10 flex h-[100vh] w-[12.5rem] flex-col">
@@ -16,71 +36,29 @@ function SideMenu() {
         <img src="/src/assets/icons/logo.png" alt="메인 로고" />
       </Link>
       <Hr />
-      <div className="flex flex-col gap-sm pb-sm pt-sm">
-        <SideMenuLink to="/" text="Home" currentPath={location.pathname} />
-        <SideMenuLink
-          to="/search"
-          text="Search"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="/explore"
-          text="Explore"
-          currentPath={location.pathname}
-        />
+      <div className="flex flex-col gap-sm py-sm">
+        {mainMenu.map(({ to, text }) => (
+          <SideMenuNavLink key={text} to={to} text={text} />
+        ))}
       </div>
       <Hr />
-      <div className="flex flex-col gap-sm pb-sm pt-sm">
-        <SideMenuLink
-          to="/auth/signin"
-          text="로그인"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="/auth/signup"
-          text="회원가입"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="/camps/0b5060ce-dfb4-4497-b0bf-34c6b7fce368/post"
-          text="캠프"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="/camps/0b5060ce-dfb4-4497-b0bf-34c6b7fce368/chat"
-          text="> 채팅"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="/camps/0b5060ce-dfb4-4497-b0bf-34c6b7fce368/post"
-          text="> 포스트"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="/demo/components"
-          text="컴포넌트 데모"
-          currentPath={location.pathname}
-        />
-        <SideMenuLink
-          to="demo/api/rest"
-          text="Mock Api"
-          currentPath={location.pathname}
-        />
+      <div className="flex flex-col gap-sm py-sm">
+        {auth ? (
+          <button className="flex" onClick={handleSignout}>
+            <span className="px-md py-sm text-text-secondary display-regular-14">
+              로그아웃
+            </span>
+          </button>
+        ) : (
+          authMenu.map(({ to, text }) => (
+            <SideMenuNavLink key={text} to={to} text={text} />
+          ))
+        )}
+        {secondaryMenu.map(({ to, text }) => (
+          <SideMenuNavLink key={text} to={to} text={text} />
+        ))}
       </div>
     </div>
-  );
-}
-
-function SideMenuLink({ to, text, currentPath }: SideMenuLinkProps) {
-  return (
-    <Link to={to} className="flex pb-sm pl-md pr-md pt-sm">
-      <Text
-        size={14}
-        color={to === currentPath ? 'text-primary' : 'text-secondary'}
-      >
-        {text}
-      </Text>
-    </Link>
   );
 }
 
@@ -88,4 +66,19 @@ function Hr() {
   return <hr className="h-[0.0625rem] border-0 bg-contour-primary" />;
 }
 
-export default SideMenu;
+function SideMenuNavLink({ to, text }: { to: string; text: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        [
+          isActive ? 'text-text-primary' : 'text-text-secondary',
+          'display-regular-14',
+          'px-md py-sm',
+        ].join(' ')
+      }
+    >
+      {text}
+    </NavLink>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [auth, setAuth] = useState<Auth | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const isSignedIn = localStorage.getItem('isSignedIn');
@@ -20,12 +21,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setAuth(result);
       } catch (error) {
         localStorage.setItem('isSignedIn', 'false');
+      } finally {
+        setIsLoading(false);
       }
     };
 
     if (isSignedIn === 'true' && auth === null) {
       refreshAuth();
+      return;
     }
+    setIsLoading(false);
   }, []);
 
   useEffect(() => {
@@ -39,7 +44,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <AuthContext.Provider value={{ auth, setAuth }}>
-      {children}
+      {!isLoading && children}
     </AuthContext.Provider>
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import router from './route/router';
+import { AuthProvider } from './contexts/AuthContext';
 
 async function enableMocking() {
   if (import.meta.env.VITE_NODE_ENV !== 'development') {
@@ -19,8 +20,10 @@ export const queryClient = new QueryClient();
 
 enableMocking().then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </AuthProvider>
   );
 });

--- a/frontend/src/pages/auth/signin/SigninForm.tsx
+++ b/frontend/src/pages/auth/signin/SigninForm.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
-import { login } from '../../../api/auth';
+import { useState, useEffect } from 'react';
+import { signin } from '../../../api/auth';
 import { useNavigate } from 'react-router-dom';
 import Input from '../../../components/input/input';
 import SubmitButton from '../../../components/button/submitButton';
+import useAuth from '../../../hooks/useAuth';
 
 const emailRegex = new RegExp('[a-z0-9]+@[a-z]+.[a-z]{2,3}');
 
@@ -14,7 +15,16 @@ export default function SigninForm() {
   const [passwordError, setPasswordError] = useState(false);
   const [signinError, setSigninError] = useState(false);
 
+  const { auth, setAuth } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (auth) {
+      navigate('/error', {
+        state: { error: '이미 로그인 하셨어요! 😉' },
+      });
+    }
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -22,7 +32,8 @@ export default function SigninForm() {
       return;
     }
     try {
-      await login(email, password);
+      const response = await signin(email, password);
+      setAuth(response);
       navigate('/');
     } catch (error) {
       setPassword('');
@@ -56,7 +67,7 @@ export default function SigninForm() {
         onBlur={handleBlurEmail}
       />
       {emailError && (
-        <div className="display-regular-14 mb-4 text-error">
+        <div className="mb-4 text-error display-regular-14">
           이메일의 형식이 맞지 않아요!
         </div>
       )}
@@ -67,13 +78,13 @@ export default function SigninForm() {
         onBlur={handleBlurPassword}
       />
       {passwordError && (
-        <div className="display-regular-14 mb-4 text-error">
+        <div className="mb-4 text-error display-regular-14">
           비밀번호의 글자 수는 4~20 사이여야 합니다!
         </div>
       )}
       <SubmitButton text="로그인" />
       {signinError && (
-        <div className="display-regular-14 mt-4 text-error">
+        <div className="mt-4 text-error display-regular-14">
           로그인에 실패했습니다!
         </div>
       )}

--- a/frontend/src/pages/auth/signup/SignupForm.tsx
+++ b/frontend/src/pages/auth/signup/SignupForm.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { signup } from '../../../api/auth';
 import { useNavigate } from 'react-router-dom';
 import Input from '../../../components/input/input';
 import SubmitButton from '../../../components/button/submitButton';
+import useAuth from '../../../hooks/useAuth';
 
 const emailRegex = new RegExp('[a-z0-9]+@[a-z]+.[a-z]{2,3}');
 
@@ -16,7 +17,16 @@ export default function SignupForm() {
   const [usernameError, setUsernameError] = useState(false);
   const [signupError, setSignupError] = useState(false);
 
+  const { auth, setAuth } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (auth) {
+      navigate('/error', {
+        state: { error: '회원가입을 하시려면 로그아웃을 먼저 해주세요! 😉' },
+      });
+    }
+  }, []);
 
   const handleBlurEmail = () => {
     const isCorrectEmailFormat = emailRegex.test(email);
@@ -44,7 +54,8 @@ export default function SignupForm() {
       return;
     }
     try {
-      await signup(email, password, username);
+      const response = await signup(email, password, username);
+      setAuth(response);
       navigate('/');
     } catch (error) {
       setSignupError(true);
@@ -64,7 +75,7 @@ export default function SignupForm() {
         onBlur={handleBlurEmail}
       />
       {emailError && (
-        <div className="display-regular-14 mb-4 text-error">
+        <div className="mb-4 text-error display-regular-14">
           이메일의 형식이 맞지 않아요!
         </div>
       )}
@@ -75,7 +86,7 @@ export default function SignupForm() {
         onBlur={handleBlurPassword}
       />
       {passwordError && (
-        <div className="display-regular-14 mb-4 text-error">
+        <div className="mb-4 text-error display-regular-14">
           비밀번호의 글자 수는 4~20 사이여야 합니다!
         </div>
       )}
@@ -86,13 +97,13 @@ export default function SignupForm() {
         onBlur={handleBlurUsername}
       />
       {usernameError && (
-        <div className="display-regular-14 mb-4 text-error">
+        <div className="mb-4 text-error display-regular-14">
           닉네임의 글자 수는 4~20 사이여야 합니다!
         </div>
       )}
       <SubmitButton text="회원가입" />
       {signupError && (
-        <div className="display-regular-14 mt-4 text-error">
+        <div className="mt-4 text-error display-regular-14">
           회원가입에 실패했습니다!
         </div>
       )}

--- a/frontend/src/pages/error/index.tsx
+++ b/frontend/src/pages/error/index.tsx
@@ -1,0 +1,16 @@
+import { Link, useLocation } from 'react-router-dom';
+
+export default function ErrorPage() {
+  const { state } = useLocation();
+
+  return (
+    <>
+      <div className="display-regular-14">
+        {state?.error ? state.error : '페이지를 찾을 수가 없었어요. 🥲'}
+      </div>
+      <Link className="text-point-blue display-regular-14" to="/">
+        홈으로
+      </Link>
+    </>
+  );
+}

--- a/frontend/src/route/AuthProtectedRoute.tsx
+++ b/frontend/src/route/AuthProtectedRoute.tsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import useAuth from '../hooks/useAuth';
+
+export default function AuthProtectedRoute() {
+  const { auth } = useAuth();
+
+  if (!auth) {
+    return <Navigate to="/auth/signin" replace />;
+  }
+}

--- a/frontend/src/route/router.tsx
+++ b/frontend/src/route/router.tsx
@@ -1,10 +1,8 @@
 import {
-  Outlet,
   Route,
   createBrowserRouter,
   createRoutesFromElements,
 } from 'react-router-dom';
-import Root from './root';
 import DemoPage from '../pages/demo/components/demoPage';
 import HomePage from '../pages/home/homePage';
 import SearchPage from '../pages/search/searchPage';
@@ -17,31 +15,36 @@ import CampPage from '../pages/camps/campPage';
 import CommunityPage from '../pages/camps/community/communityPage';
 import ApiPage from '../pages/demo/api/apiPage';
 import EditPage from '../pages/camps/edit/editPage';
+import Layout from '../components/Layout';
+import ErrorPage from '../pages/error';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
-    <>
-      <Route path="/auth">
+    <Route path="/" errorElement={<ErrorPage />}>
+      <Route path="auth">
         <Route path="signin" element={<SigninPage />} />
         <Route path="signup" element={<SignupPage />} />
       </Route>
-      <Route path="/" element={<Root />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/search" element={<SearchPage />} />
-        <Route path="/explore" element={<ExplorePage />} />
-        <Route path="/camps" element={<CampPage />}>
-          <Route path=":campId" element={<Outlet />}>
+      <Route element={<Layout />}>
+        <Route index element={<HomePage />} />
+        <Route path="search" element={<SearchPage />} />
+        <Route path="explore" element={<ExplorePage />} />
+        <Route path="camps" element={<CampPage />}>
+          <Route path=":campId">
             <Route path="chat" element={<ChatPage />} />
             <Route path="community" element={<CommunityPage />} />
             <Route path="post" element={<PostPage />} />
             <Route path="edit" element={<EditPage />} />
           </Route>
         </Route>
-        <Route path="/demo/components" element={<DemoPage />} />
-        <Route path="/demo/api/rest" element={<ApiPage />} />
-        <Route path="/demo/api/scenario" element={<ApiPage />} />
+        <Route path="demo">
+          <Route path="components" element={<DemoPage />} />
+          <Route path="api/rest" element={<ApiPage />} />
+          <Route path="api/scenario" element={<ApiPage />} />
+        </Route>
+        <Route path="error" element={<ErrorPage />} />
       </Route>
-    </>
+    </Route>
   )
 );
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://223.130.146.223:3000',
+        target: 'http://223.130.133.168:3000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
         secure: false,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- [BGP-138]
- [BGP-139]
- [BGP-141]

### 변경 사항
- AuthContext에 비동기 처리가 있어서 isLoading 상태를 추가하여 하위 컴포넌트에서 auth를 비동기 처리후에 사용가능하도록 수정
- 사이드바 메뉴를 리액트 라우터가 지원하는 네이티브 컴포넌트 NavLink를 사용, map을 사용하여 유지보수 하기 쉽게 수정
- 사이드바 메뉴에서 로그인 상태에서는 로그아웃 버튼이 나오도록 수정
- 라우팅 계층 구조를 더 보기 쉽게 수정하고 Not Found 에러 페이지 추가
- 로그인 상태에서 로그인, 회원가입 페이지 진입 시에 에러 페이지로 에러 메세지와 함께 리다이렉트

### 동작 확인
![1](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/cea9e92a-ab4e-454c-ad51-8511335aa5c4)
로그인 하기 전

![2](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/2602655c-1076-49b9-bc3d-162cfa69565d)
로그인 후 로그아웃 버튼 표시

![3](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/d886aaf9-20aa-4e1e-aa5d-1ea491c4baa2)
로그인 상태에서 로그인 페이지 진입 시 리다이렉트 

![4](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/05577458-cc91-44b9-aff5-f4a893b9038a)
로그인 상태에서 회원가입 페이지 진입 시 리다이렉트


[BGP-138]: https://coli-heo.atlassian.net/browse/BGP-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-139]: https://coli-heo.atlassian.net/browse/BGP-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-141]: https://coli-heo.atlassian.net/browse/BGP-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ