### PR TITLE
[BE] 구독 여부 API 작성 및 로그인 인증 Guard 추가

### DIFF
--- a/backend/src/auth/auth.guard.ts
+++ b/backend/src/auth/auth.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthService } from './auth.service'; // AuthService의 경로에 따라 수정하세요.
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly authService: AuthService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const publicId = request.cookies && request.cookies['publicId'];
+    if (!publicId) return false;
+
+    const socket = context.switchToWs().getClient();
+    // console.log(socket);
+
+    // 여기에 실제 인증 로직을 추가하고 authService를 사용할 수 있습니다.
+    const isAuthorized = this.authService.validateUser(publicId);
+    return isAuthorized;
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UserRepository } from 'src/user/user.repository';
+import { AuthGuard } from './auth.guard';
 
 @Module({
   imports: [],
   controllers: [AuthController],
-  providers: [AuthService, UserRepository],
-  exports: [AuthService],
+  providers: [AuthGuard, AuthService, UserRepository],
+  exports: [AuthGuard, AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -47,7 +47,7 @@ export class AuthService {
   }
 
   async checkLogin(publicId: string){
-    if(this.sessions.includes(publicId)){
+    if(this.validateUser(publicId)){
       const user = await this.userRepository.findUserByPublicId(publicId);
       return  {
         email: user.email,
@@ -55,6 +55,10 @@ export class AuthService {
         isMaster: user.isMaster
       };
     }
+  }
+
+  validateUser(publicId : string) {
+    return this.sessions.includes(publicId);
   }
   
 }

--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -19,6 +19,20 @@ import { Request, Response } from 'express';
 export class CampController {
   constructor(private readonly campService: CampService) {}
 
+  @Get('subscriptions')
+  getSubscriptions(@Req() request: Request) {
+    // 쿠키의 publicId로 userId 찾기위해 넘겨주기
+    return this.campService.getSubscriptions(request.cookies['publicId']);
+  }
+  @Get('subscriptions/:campName')
+  getSubscription(
+    @Req() request: Request,
+    @Param('campName') campName: string
+    ) {
+    // 쿠키의 publicId로 userId 찾기위해 넘겨주기
+    return this.campService.getSubscription(request.cookies['publicId'], campName);
+  }
+
   @Post()
   create(@Body() createCampDto: CreateCampDto) {
     return this.campService.create(createCampDto);
@@ -39,6 +53,8 @@ export class CampController {
     // 쿠키의 publicId로 userId 찾기위해 넘겨주기
     this.campService.subscribe(request.cookies['publicId'], campName);
   }
+
+
 
   // @Patch(':id')
   // update(@Param('id') id: string, @Body() updateCampDto: UpdateCampDto) {

--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -7,15 +7,18 @@ import {
   Param,
   Delete,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import { CampService } from './camp.service';
 import { CreateCampDto } from './dto/create-camp.dto';
 import { UpdateCampDto } from './dto/update-camp.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @ApiTags('camps')
 @Controller('camps')
+@UseGuards(AuthGuard)
 export class CampController {
   constructor(private readonly campService: CampService) {}
 

--- a/backend/src/camp/camp.module.ts
+++ b/backend/src/camp/camp.module.ts
@@ -8,12 +8,14 @@ import { SubscriptionRepository } from './subscription.repository';
 import { Subscription } from './entities/subscription.entity';
 import { UserModule } from 'src/user/user.module';
 import { SubscriptionService } from './subscription.service';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Camp]),
     TypeOrmModule.forFeature([Subscription]),
     UserModule,
+    AuthModule
   ],
   controllers: [CampController],
   providers: [

--- a/backend/src/camp/camp.service.ts
+++ b/backend/src/camp/camp.service.ts
@@ -36,12 +36,17 @@ export class CampService {
     });
     // throw new Error('Method not implemented.');
   }
-
-  // update(id: number, updateCampDto: UpdateCampDto) {
-  //   return `This action updates a #${id} camp`;
-  // }
-
-  // remove(id: number) {
-  //   return `This action removes a #${id} camp`;
-  // }
+  async getSubscriptions(publicId: string){
+    const user = await this.userService.findUserByPublicId(publicId);
+    const camperId = user.id;
+    console.log("campid",camperId)
+    return this.subscriptionService.findAll(camperId);
+  }
+  async getSubscription(publicId: string, campName: string){
+    const user = await this.userService.findUserByPublicId(publicId);
+    const camperId = user.id;
+    const camp = await this.findOne(campName);
+    const masterId = camp.masterId;
+    return this.subscriptionService.findOne(camperId, masterId);
+  }
 }

--- a/backend/src/camp/subscription.repository.ts
+++ b/backend/src/camp/subscription.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { Subscription } from './entities/subscription.entity';
 import { CreateSubscriptionDto } from './dto/create-subscription.dto';
+import { concatMap } from 'rxjs';
 
 @Injectable()
 export class SubscriptionRepository {
@@ -18,5 +19,8 @@ export class SubscriptionRepository {
 
   findOne(camperId: number, masterId: number) {
     return this.subscriptionRepository.findOneBy({ camperId, masterId });
+  }
+  findAll(camperId: number){
+    return this.subscriptionRepository.findBy({camperId})
   }
 }

--- a/backend/src/camp/subscription.service.ts
+++ b/backend/src/camp/subscription.service.ts
@@ -16,4 +16,8 @@ export class SubscriptionService {
   findOne(camperId: number, masterId: number) {
     return this.subscriptionRepository.findOne(camperId, masterId);
   }
+  findAll(camperId: number){
+    return this.subscriptionRepository.findAll(camperId)
+  }
+
 }

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -6,18 +6,21 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { CreateChatDto } from './dto/create-chat.dto';
 import { UpdateChatDto } from './dto/update-chat.dto';
 import { ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @ApiTags('chats')
 @Controller('chats')
+@UseGuards(AuthGuard)
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 
-  @Post('s')
+  @Post('')
   create(@Body() createChatDto: CreateChatDto) {
     return this.chatService.create(createChatDto);
   }

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -7,9 +7,15 @@ import { ChatRepository } from './chat.repository';
 import { ChatGateway } from './chat.gateway';
 import { UserModule } from 'src/user/user.module';
 import { CampModule } from 'src/camp/camp.module';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Chat]), UserModule, CampModule],
+  imports: [
+    TypeOrmModule.forFeature([Chat]),
+    UserModule,
+    CampModule,
+    AuthModule,
+  ],
   controllers: [ChatController],
   providers: [ChatService, ChatRepository, ChatGateway],
   exports: [ChatService, ChatGateway],

--- a/backend/src/http/auth.http
+++ b/backend/src/http/auth.http
@@ -8,12 +8,12 @@ POST {{server}}/auth/users
 Content-Type: application/json
 
 {
-    "email" : "master1@fancamp.com",
+    "email" : "master2@fancamp.com",
     "password": "1234",
-    "chatName": "master1",
-    "publicId": "master1",
+    "chatName": "master2",
+    "publicId": "master2",
     "profileImage": "",
-    "isMaster": false
+    "isMaster": true
 }
 
 

--- a/backend/src/http/camp.http
+++ b/backend/src/http/camp.http
@@ -8,19 +8,25 @@ POST {{server}}/camps
 Content-Type: application/json
 
 {
-    "campName" : "camp3",
+    "campName" : "camp2",
     "masterId": "5",
-    "bannerImage": "33"
+    "bannerImage": ""
 }
 
 ###
-GET {{server}}/camp/22
+GET {{server}}/camps/camp1
 
 ### 구독하기
-POST {{server}}/camps/subscriptions/camp1
+POST {{server}}/camps/subscriptions/camp2
 Content-Type: application/json
 
 {
-    "camperId" : "8",
-    "masterId": "2"
+    "camperId" : "1",
+    "masterId": "5"
 }
+
+### 모든 자신의 구독 가져오기
+GET {{server}}/camps/subscriptions
+
+###
+GET {{server}}/camps/subscriptions/camp2


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가

### 관련 이슈
- [BGP-134]
- [BGP-142]

### 변경 사항
1. 구독 여부를 판단하고 자기가 구독한 정보를 가져오는 API를 작성했습니다.
2. 로그인이 안되면 요청이 안되게 판단하는 guard를 사용했습니다.


[BGP-134]: https://coli-heo.atlassian.net/browse/BGP-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-142]: https://coli-heo.atlassian.net/browse/BGP-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ