### PR TITLE
[BE] 이전 메세지 가져오기 api 작성 및 camp 생성 api 작성

### DIFF
--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -30,15 +30,18 @@ export class CampController {
   @Get('subscriptions/:campName')
   getSubscription(
     @Req() request: Request,
-    @Param('campName') campName: string
-    ) {
+    @Param('campName') campName: string,
+  ) {
     // 쿠키의 publicId로 userId 찾기위해 넘겨주기
-    return this.campService.getSubscription(request.cookies['publicId'], campName);
+    return this.campService.getSubscription(
+      request.cookies['publicId'],
+      campName,
+    );
   }
 
   @Post()
-  create(@Body() createCampDto: CreateCampDto) {
-    return this.campService.create(createCampDto);
+  create(@Body() createCampDto: CreateCampDto, @Req() request: Request) {
+    return this.campService.create(createCampDto, request.cookies['publicId']);
   }
 
   // @Get()
@@ -56,8 +59,6 @@ export class CampController {
     // 쿠키의 publicId로 userId 찾기위해 넘겨주기
     this.campService.subscribe(request.cookies['publicId'], campName);
   }
-
-
 
   // @Patch(':id')
   // update(@Param('id') id: string, @Body() updateCampDto: UpdateCampDto) {

--- a/backend/src/camp/camp.repository.ts
+++ b/backend/src/camp/camp.repository.ts
@@ -11,12 +11,15 @@ export class CampRepository {
     this.campRepository = this.dataSource.getRepository(Camp);
   }
 
-  createCamp(createCampDto: CreateCampDto) {
-    console.log(createCampDto);
-    return this.campRepository.save(createCampDto);
+  createCamp(createCampDto: CreateCampDto, masterId: number) {
+    return this.campRepository.save({
+      campName: createCampDto.campName,
+      bannerImage: createCampDto.bannerImage,
+      masterId: masterId,
+    });
   }
 
   findOneByCampName(campName: string) {
     return this.campRepository.findOneBy({ campName });
-  } 
+  }
 }

--- a/backend/src/camp/dto/create-camp.dto.ts
+++ b/backend/src/camp/dto/create-camp.dto.ts
@@ -1,14 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsEmail, IsString, Length, isInt, IsNumberString } from 'class-validator';
+import {
+  IsBoolean,
+  IsEmail,
+  IsString,
+  Length,
+  isInt,
+  IsNumberString,
+} from 'class-validator';
 
 export class CreateCampDto {
   @IsString()
   @ApiProperty()
   campName: string;
-
-  @IsNumberString()
-  @ApiProperty()
-  masterId: number;
 
   @IsString()
   @ApiProperty()

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -7,12 +7,15 @@ import {
   Param,
   Delete,
   UseGuards,
+  Res,
+  Req,
 } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { CreateChatDto } from './dto/create-chat.dto';
 import { UpdateChatDto } from './dto/update-chat.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from 'src/auth/auth.guard';
+import { Request, Response } from 'express';
 
 @ApiTags('chats')
 @Controller('chats')
@@ -30,10 +33,14 @@ export class ChatController {
   //   return this.chatService.findAll();
   // }
 
-  // @Get(':id')
-  // findOne(@Param('id') id: string) {
-  //   return this.chatService.findOne(+id);
-  // }
+  @Get(':campName')
+  async findOne(@Param('campName') campName: string, @Req() request: Request) {
+    const result = await this.chatService.getPreviousChats(
+      campName,
+      request.cookies['publicId'],
+    );
+    return result;
+  }
 
   // @Patch(':id')
   // update(@Param('id') id: string, @Body() updateChatDto: UpdateChatDto) {

--- a/backend/src/chat/chat.repository.ts
+++ b/backend/src/chat/chat.repository.ts
@@ -16,7 +16,16 @@ export class ChatRepository {
     return this.chatRepository.save(createChatDto);
   }
 
-  //   findUserByMasterId(masterId: string) {
-  //     return this.chatRepository.findOneBy({ masterId });
-  //   }
+  async findChatsByUserIdOrMasterId(
+    userId: number,
+    masterId: number,
+  ): Promise<Chat[]> {
+    return await this.chatRepository
+      .createQueryBuilder('chat')
+      .where(
+        '(chat.senderId = :userId AND chat.masterId = :masterId) OR chat.senderId = :masterId',
+        { userId, masterId },
+      )
+      .getMany();
+  }
 }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -2,12 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { CreateChatDto } from './dto/create-chat.dto';
 import { UpdateChatDto } from './dto/update-chat.dto';
 import { ChatRepository } from './chat.repository';
-import {UserService} from '../user/user.service';
-import {CampService} from '../camp/camp.service'
+import { UserService } from '../user/user.service';
+import { CampService } from '../camp/camp.service';
 
 @Injectable()
 export class ChatService {
-  constructor(private readonly chatRepository: ChatRepository, private readonly userService: UserService, private readonly campService: CampService) {}
+  constructor(
+    private readonly chatRepository: ChatRepository,
+    private readonly userService: UserService,
+    private readonly campService: CampService,
+  ) {}
   create(createChatDto: CreateChatDto) {
     return this.chatRepository.createChat(createChatDto);
   }
@@ -17,20 +21,31 @@ export class ChatService {
     const camp = await this.campService.findOne(campName);
     const createDto: CreateChatDto = {
       stringContent: message,
-      sender: user.id.toString(),
-      masterId: camp.masterId.toString(),
+      senderId: user.id,
+      masterId: camp.masterId,
       picContent: '',
     };
     return this.chatRepository.createChat(createDto);
   }
 
-
   async getRoomName(campName: string) {
     const camp = await this.campService.findOne(campName);
     const roomName = camp.campId.toString();
-    return {roomName :roomName, detailRoomName:''.concat(roomName, "-detail")};
+    return {
+      roomName: roomName,
+      detailRoomName: ''.concat(roomName, '-detail'),
+    };
   }
-  
+
+  async getPreviousChats(campName: string, publicId: string) {
+    const camp = await this.campService.findOne(campName);
+    const user = await this.userService.findUserByPublicId(publicId);
+    return this.chatRepository.findChatsByUserIdOrMasterId(
+      user.id,
+      camp.masterId,
+    );
+  }
+
   // findAll() {
   //   return `This action returns all chat`;
   // }

--- a/backend/src/chat/dto/create-chat.dto.ts
+++ b/backend/src/chat/dto/create-chat.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsEmail, IsString, Length } from 'class-validator';
+import {
+  IsBoolean,
+  IsEmail,
+  IsNumber,
+  IsString,
+  Length,
+} from 'class-validator';
 
 export class CreateChatDto {
   @IsString()
@@ -10,11 +16,11 @@ export class CreateChatDto {
   @ApiProperty()
   picContent: string = '';
 
-  @IsString()
+  @IsNumber()
   @ApiProperty()
-  sender: string;
+  senderId: number;
 
-  @IsString()
+  @IsNumber()
   @ApiProperty()
-  masterId: string;
+  masterId: number;
 }

--- a/backend/src/chat/entities/chat.entity.ts
+++ b/backend/src/chat/entities/chat.entity.ts
@@ -19,9 +19,9 @@ export class Chat {
   @Column({ type: 'varchar', nullable: true })
   picContent: string = '';
 
-  @Column({ type: 'varchar', nullable: false })
-  sender: string;
+  @Column({ type: 'int', nullable: false })
+  senderId: number;
 
-  @Column({ type: 'varchar', nullable: false })
-  masterId: string;
+  @Column({ type: 'int', nullable: false })
+  masterId: number;
 }

--- a/backend/src/http/chat.http
+++ b/backend/src/http/chat.http
@@ -3,16 +3,18 @@
 # @server = http://175.45.194.10:3000
 # @server = http://223.130.146.223:3000
 
-### 회원가입 요청~
-POST {{server}}/chat
+### 메세지 생성
+POST {{server}}/chats
 Content-Type: application/json
 
 {
-    "createdAt" : "2023-12-22",
-    "stringContent": "22",
-    "picContent": "33",
-    "sender": "1",
-    "masterId": "12"
+    "stringContent": "마스터2 보냅니다 안녕하세요2",
+    "picContent": "",
+    "senderId": 5,
+    "masterId": 5
 }
 
+
+### 이전메세지 가져오기?
+GET {{server}}/chats/camp2
 

--- a/backend/src/http/chat.http
+++ b/backend/src/http/chat.http
@@ -8,13 +8,13 @@ POST {{server}}/chats
 Content-Type: application/json
 
 {
-    "stringContent": "마스터2 보냅니다 안녕하세요2",
+    "stringContent": "캠퍼1 보냅니다 (닉네임)안녕!",
     "picContent": "",
-    "senderId": 5,
-    "masterId": 5
+    "senderId": 1,
+    "masterId": 4
 }
 
 
 ### 이전메세지 가져오기?
-GET {{server}}/chats/camp2
+GET {{server}}/chats/camp1
 


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [X] 버그 수정

### 관련 이슈
- [BGP-38]
- [BGP-91]

### 변경 사항
1. `/chats/:campName`으로 들어오면 쿠키의 publicId를 보고 요청을 한다
2. chat repository에서 요청에 대해 쿼리를 통해
`(chat.senderId = :userId AND chat.masterId = :masterId) OR chat.senderId = :masterId`
인 경우를 다 가져온다
3. `entity type`이 `char`로 되어있는 부분 int로 수정
4. `/camp`로 `post`요청 api 작성
5. 닉네임을 replace하는 경우
1) 요청을 준 user가 캠퍼이고
2) 마스터가 보낸 메세지의 경우에만 (닉네임)을 자신의 chatName으로 replace 한다.


### 동작 확인
#### 이전 채팅 가져오기

<img width="436" alt="스크린샷 2023-11-21 오후 10 06 49" src="https://github.com/boostcampwm2023/web02-fancamp/assets/101859033/4b957811-921c-46a0-af64-efde57a8e0dd">

#### 캠퍼는 캠프 생성 불가

<img width="1496" alt="스크린샷 2023-11-21 오후 9 54 20" src="https://github.com/boostcampwm2023/web02-fancamp/assets/101859033/4028083a-7391-48f4-b720-ac8106f433f7">

#### (닉네임)으로 마스터가 보낸 경우에는 user.chatName으로 replace 해주기
<img width="414" alt="스크린샷 2023-11-21 오후 10 21 25" src="https://github.com/boostcampwm2023/web02-fancamp/assets/101859033/6924a505-5edb-4ddb-91b2-a74f3cc5c0fb">

#### (닉네임)으로 캠퍼가 보낸 경우에는 replace를 해주지 않는다.
<img width="401" alt="스크린샷 2023-11-21 오후 10 28 04" src="https://github.com/boostcampwm2023/web02-fancamp/assets/101859033/97c48f0a-2786-4635-acf6-4d1d5534137a">


[BGP-38]: https://coli-heo.atlassian.net/browse/BGP-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-91]: https://coli-heo.atlassian.net/browse/BGP-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ