### PR TITLE
[BE] 전체 캠프 목록 조회 추가 및 마스터 회원가입 시 캠프 자동 생성

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,8 +14,6 @@ import { ImageModule } from './image/image.module';
 
 @Module({
   imports: [
-    UserModule,
-    AuthModule,
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env',
@@ -32,7 +30,9 @@ import { ImageModule } from './image/image.module';
       entities: [User],
       autoLoadEntities: true,
     }),
+    UserModule,
     CampModule,
+    AuthModule,
     ChatModule,
     PostModule,
     ImageModule,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -3,9 +3,10 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UserRepository } from 'src/user/user.repository';
 import { AuthGuard } from './auth.guard';
+import { CampModule } from 'src/camp/camp.module';
 
 @Module({
-  imports: [],
+  imports: [CampModule],
   controllers: [AuthController],
   providers: [AuthGuard, AuthService, UserRepository],
   exports: [AuthGuard, AuthService],

--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -44,10 +44,10 @@ export class CampController {
     return this.campService.create(createCampDto, request.cookies['publicId']);
   }
 
-  // @Get()
-  // findAll() {
-  //   return this.campService.findAll();
-  // }
+  @Get()
+  findAll() {
+    return this.campService.findAll();
+  }
 
   @Get(':campName')
   findOne(@Param('campName') campName: string) {

--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -39,11 +39,6 @@ export class CampController {
     );
   }
 
-  @Post()
-  create(@Body() createCampDto: CreateCampDto, @Req() request: Request) {
-    return this.campService.create(createCampDto, request.cookies['publicId']);
-  }
-
   @Get()
   findAll() {
     return this.campService.findAll();

--- a/backend/src/camp/camp.module.ts
+++ b/backend/src/camp/camp.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { CampService } from './camp.service';
 import { CampController } from './camp.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -12,10 +12,10 @@ import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   imports: [
+    forwardRef(() => AuthModule),
     TypeOrmModule.forFeature([Camp]),
     TypeOrmModule.forFeature([Subscription]),
     UserModule,
-    AuthModule
   ],
   controllers: [CampController],
   providers: [

--- a/backend/src/camp/camp.repository.ts
+++ b/backend/src/camp/camp.repository.ts
@@ -19,6 +19,10 @@ export class CampRepository {
     });
   }
 
+  findAll() {
+    return this.campRepository.find();
+  }
+
   findOneByCampName(campName: string) {
     return this.campRepository.findOneBy({ campName });
   }

--- a/backend/src/camp/camp.repository.ts
+++ b/backend/src/camp/camp.repository.ts
@@ -11,12 +11,8 @@ export class CampRepository {
     this.campRepository = this.dataSource.getRepository(Camp);
   }
 
-  createCamp(createCampDto: CreateCampDto, masterId: number) {
-    return this.campRepository.save({
-      campName: createCampDto.campName,
-      bannerImage: createCampDto.bannerImage,
-      masterId: masterId,
-    });
+  createCamp(createCampDto: CreateCampDto) {
+    return this.campRepository.save(createCampDto);
   }
 
   findAll() {

--- a/backend/src/camp/camp.service.ts
+++ b/backend/src/camp/camp.service.ts
@@ -13,16 +13,8 @@ export class CampService {
     private readonly subscriptionService: SubscriptionService,
     private readonly userService: UserService,
   ) {}
-  async create(createCampDto: CreateCampDto, publicId: string) {
-    const user = await this.userService.findUserByPublicId(publicId);
-    if (user.isMaster) {
-      const result = await this.campRepository.createCamp(
-        createCampDto,
-        user.id,
-      );
-      return { campName: result.campName, bannerImage: result.bannerImage };
-    }
-    throw new UnauthorizedException("camper can't make camp");
+  async create(createCampDto: CreateCampDto) {
+    return this.campRepository.createCamp(createCampDto);
   }
 
   findAll() {

--- a/backend/src/camp/camp.service.ts
+++ b/backend/src/camp/camp.service.ts
@@ -25,9 +25,9 @@ export class CampService {
     throw new UnauthorizedException("camper can't make camp");
   }
 
-  // findAll() {
-  //   return `This action returns all camp`;
-  // }
+  findAll() {
+    return this.campRepository.findAll();
+  }
 
   findOne(campName: string) {
     return this.campRepository.findOneByCampName(campName);

--- a/backend/src/camp/dto/create-camp.dto.ts
+++ b/backend/src/camp/dto/create-camp.dto.ts
@@ -6,6 +6,7 @@ import {
   Length,
   isInt,
   IsNumberString,
+  IsNumber,
 } from 'class-validator';
 
 export class CreateCampDto {
@@ -17,4 +18,8 @@ export class CreateCampDto {
   @ApiProperty()
   // TODO: default 값을 프로필 기본 이미지로 바꾸기
   bannerImage: string = '';
+
+  @IsNumber()
+  @ApiProperty()
+  masterId: number;
 }

--- a/backend/src/http/auth.http
+++ b/backend/src/http/auth.http
@@ -3,15 +3,15 @@
 # @server = http://175.45.194.10:3000
 # @server = http://223.130.146.223:3000
 
-### 회원가입 요청~
+### 회원가입 요청(마스터) - 캠프도 생성되야함.
 POST {{server}}/auth/users
 Content-Type: application/json
 
 {
-    "email" : "master2@fancamp.com",
+    "email" : "master4@fancamp.com",
     "password": "1234",
-    "chatName": "master2",
-    "publicId": "master2",
+    "chatName": "master4",
+    "publicId": "master4",
     "profileImage": "",
     "isMaster": true
 }

--- a/backend/src/http/camp.http
+++ b/backend/src/http/camp.http
@@ -3,7 +3,7 @@
 # @server = http://175.45.194.10:3000
 # @server = http://223.130.146.223:3000
 
-### 회원가입 요청~
+### 캠프 생성
 POST {{server}}/camps
 Content-Type: application/json
 
@@ -12,6 +12,10 @@ Content-Type: application/json
     "masterId": "5",
     "bannerImage": ""
 }
+
+
+### 캠프 전부 가져오기
+GET {{server}}/camps
 
 ###
 GET {{server}}/camps/camp1


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- [BGP-25]
- [BGP-18]

### 변경 사항
1. 전체 캠프 목록 조회 `GET /camps` 추가
2. 마스터가 회원가입 할 때, 마스터의 publicId로 campName을 하는 default Camp 생성 로직 추가
3. auth 와 camp의 상호의존성 해결

### 동작 확인
[의존성 해결 노션페이지](https://coli-pasta.notion.site/42c31f729cea4fbb82f55ac90f7822c0?pvs=4)

[BGP-25]: https://coli-heo.atlassian.net/browse/BGP-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-18]: https://coli-heo.atlassian.net/browse/BGP-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ