### PR TITLE
Fix/api

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy to Production
 on:
   push:
     branches: [dev]
-  pull_request:
-    branches: [dev]
 
 jobs:
   get-dev-branch-and-deploy:

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -25,6 +25,7 @@ export class AuthService {
       campName: publicId,
       bannerImage: '',
       masterId: id,
+      content: '',
     });
     return {
       publicId,

--- a/backend/src/camp/camp.module.ts
+++ b/backend/src/camp/camp.module.ts
@@ -9,6 +9,7 @@ import { Subscription } from './entities/subscription.entity';
 import { UserModule } from 'src/user/user.module';
 import { SubscriptionService } from './subscription.service';
 import { AuthModule } from 'src/auth/auth.module';
+import { ImageModule } from 'src/image/image.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { AuthModule } from 'src/auth/auth.module';
     TypeOrmModule.forFeature([Camp]),
     TypeOrmModule.forFeature([Subscription]),
     UserModule,
+    ImageModule,
   ],
   controllers: [CampController],
   providers: [

--- a/backend/src/camp/camp.repository.ts
+++ b/backend/src/camp/camp.repository.ts
@@ -19,11 +19,15 @@ export class CampRepository {
     return this.campRepository.find();
   }
 
-  findOneByMasterId(masterId: number){
-    return this.campRepository.findOneBy({masterId});
+  findOneByMasterId(masterId: number) {
+    return this.campRepository.findOneBy({ masterId });
   }
 
   findOneByCampName(campName: string) {
     return this.campRepository.findOneBy({ campName });
+  }
+
+  async update(camp: Camp) {
+    return this.campRepository.save(camp);
   }
 }

--- a/backend/src/camp/dto/create-camp.dto.ts
+++ b/backend/src/camp/dto/create-camp.dto.ts
@@ -14,12 +14,16 @@ export class CreateCampDto {
   @ApiProperty()
   campName: string;
 
-  @IsString()
-  @ApiProperty()
-  // TODO: default 값을 프로필 기본 이미지로 바꾸기
-  bannerImage: string = '';
-
   @IsNumber()
   @ApiProperty()
   masterId: number;
+
+  @IsString()
+  @ApiProperty()
+  // TODO: default 값을 프로필 기본 이미지로 바꾸기
+  bannerImage?: string = '';
+
+  @IsString()
+  @ApiProperty()
+  content?: string = '';
 }

--- a/backend/src/camp/dto/update-camp.dto.ts
+++ b/backend/src/camp/dto/update-camp.dto.ts
@@ -1,4 +1,9 @@
-import { PartialType } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { CreateCampDto } from './create-camp.dto';
+import { IsString } from 'class-validator';
 
-export class UpdateCampDto extends PartialType(CreateCampDto) {}
+export class UpdateCampDto extends PartialType(CreateCampDto) {
+  @IsString()
+  @ApiProperty()
+  content?: string = '';
+}

--- a/backend/src/camp/entities/camp.entity.ts
+++ b/backend/src/camp/entities/camp.entity.ts
@@ -11,6 +11,9 @@ export class Camp {
   @Column({ type: 'int', nullable: false, unique: true })
   masterId: number;
 
-  @Column({ type: 'varchar', nullable: false })
+  @Column({ type: 'varchar', nullable: true })
   bannerImage: string = '';
+
+  @Column({ type: 'varchar', nullable: true })
+  content: string = '';
 }

--- a/backend/src/camp/subscription.repository.ts
+++ b/backend/src/camp/subscription.repository.ts
@@ -20,7 +20,11 @@ export class SubscriptionRepository {
   findOne(camperId: number, masterId: number) {
     return this.subscriptionRepository.findOneBy({ camperId, masterId });
   }
-  findAll(camperId: number){
-    return this.subscriptionRepository.findBy({camperId})
+  findAll(camperId: number) {
+    return this.subscriptionRepository.findBy({ camperId });
+  }
+
+  count(masterId: number) {
+    return this.subscriptionRepository.count({ where: { masterId } });
   }
 }

--- a/backend/src/camp/subscription.service.ts
+++ b/backend/src/camp/subscription.service.ts
@@ -36,4 +36,8 @@ export class SubscriptionService {
       }),
     );
   }
+
+  async getCount(masterId: number) {
+    return this.subscriptionRepository.count(masterId);
+  }
 }

--- a/backend/src/http/comment.http
+++ b/backend/src/http/comment.http
@@ -2,21 +2,24 @@
 @server = http://localhost:3000
 # @server = http://223.130.146.223:3000
 
+### 포스트 id로 comment 조회 
+GET {{server}}/posts/28/comments
+
+
 ### 포스트 id로 comment 생성하기
-POST {{server}}/posts/comments
+POST {{server}}/posts/28/comments
 Content-Type: application/json
 
 {
-    "content": "hello33",
-    "postId": 1
+    "content": "hello33"
 }
 
 ### 포스트 id로 코멘트 지우기
-DELETE  {{server}}/posts/comments/1 
+DELETE  {{server}}/posts/28/comments/7
 
 
 ### 글 내용 수정
-PATCH {{server}}/posts/comments/2
+PATCH {{server}}/posts/28/comments/5
 Content-Type: application/json
 
 {

--- a/backend/src/http/like.http
+++ b/backend/src/http/like.http
@@ -3,10 +3,10 @@
 # @server = http://223.130.146.223:3000
 
 ### 포스트 id로 좋아요 생성하기 -> 중복처리
-POST {{server}}/posts/likes/1
+POST {{server}}/posts/28/likes/
 
 ### 포스트 id로 좋아요 지우기  
-DELETE {{server}}/posts/likes/1
+DELETE {{server}}/posts/28/likes
 
 ### postId로 좋아요 수 가져오기
-GET {{server}}/posts/likes/1
+GET {{server}}/posts/28/likes

--- a/backend/src/http/post.http
+++ b/backend/src/http/post.http
@@ -11,11 +11,11 @@ Content-Type: application/json
     "campName" : "camp1"
 }
 
-### 포스트 id로 가져오기
-GET {{server}}/posts/1
+### 포스트 id로 가져오기 
+GET {{server}}/posts/28
 
 ### campName로 가져오기
-GET {{server}}/posts/camp/camp1
+GET {{server}}/posts/camps/camp1
 
 ### 글 내용 수정
 PATCH {{server}}/posts/7

--- a/backend/src/image/dto/create-image.dto.ts
+++ b/backend/src/image/dto/create-image.dto.ts
@@ -10,10 +10,6 @@ export class CreateImageDto {
   @ApiProperty()
   postId: number;
 
-  @IsNumber()
-  @ApiProperty()
-  userId: number;
-
   @IsString()
   @ApiProperty()
   mimetype: string;

--- a/backend/src/image/entities/image.entity.ts
+++ b/backend/src/image/entities/image.entity.ts
@@ -11,9 +11,6 @@ export class Image {
   @Column({ type: 'int', nullable: true })
   postId: number;
 
-  @Column({ type: 'int', nullable: true })
-  userId: number;
-
   @Column({ type: 'boolean', nullable: true, default: false })
   isDeleted: boolean;
 

--- a/backend/src/image/image.service.ts
+++ b/backend/src/image/image.service.ts
@@ -30,7 +30,7 @@ export class ImageService {
     await Promise.all(
       files.map(async (file, index) => {
         const fileName = `${campId}-${postId}_${index}`;
-        await this.uploadFile(file, fileName, postId, -1);
+        await this.uploadFile(file, fileName, postId);
       }),
     );
   }
@@ -39,7 +39,6 @@ export class ImageService {
     file: Express.Multer.File,
     fileName: string,
     postId: number,
-    userId: number,
   ) {
     const command = new PutObjectCommand({
       Bucket: this.bucket_name,
@@ -52,16 +51,18 @@ export class ImageService {
       const response = await this.s3Client.send(command);
       const fileUrl = `${process.env.END_POINT}/${this.bucket_name}/${fileName}`;
       const mimetype = file.mimetype;
-      this.createImage({ fileUrl, postId, userId, mimetype });
+      if (postId !== -1) {
+        this.imageRepository.create({ fileUrl, postId, mimetype });
+      }
       return fileUrl;
     } catch (err) {
       console.error(err);
     }
   }
 
-  async createImage(createImageDto: CreateImageDto) {
-    return this.imageRepository.create(createImageDto);
-  }
+  // async createImage(createImageDto: CreateImageDto) {
+  //   return this.imageRepository.create(createImageDto);
+  // }
 
   async findImagesByPostId(postId: number) {
     const images = await this.imageRepository.findByPostId(postId);

--- a/backend/src/post/comment.repository.ts
+++ b/backend/src/post/comment.repository.ts
@@ -12,11 +12,11 @@ export class CommentRepository {
     this.commentRepository = this.dataSource.getRepository(Comment);
   }
 
-  create(createCommentDto: CreateCommentDto, userId: number) {
+  create(postId: number, content: string, userId: number) {
     return this.commentRepository.save({
-      content: createCommentDto.content,
+      content,
       userId,
-      postId: createCommentDto.postId,
+      postId,
       isDeleted: false,
     });
   }
@@ -24,8 +24,8 @@ export class CommentRepository {
     return this.commentRepository.findOneBy({ commentId });
   }
 
-  update(comment: Comment, updateCommentDto: UpdateCommenttDto) {
-    comment.content = updateCommentDto.content;
+  update(comment: Comment, content: string) {
+    comment.content = content;
     return this.commentRepository.save(comment);
   }
 
@@ -35,7 +35,7 @@ export class CommentRepository {
   }
 
   findByPostId(postId: number): Promise<Comment[]> {
-    return this.commentRepository.findBy({ postId });
+    return this.commentRepository.findBy({ postId, isDeleted: false });
   }
 
   countByPostId(postId: number): number | PromiseLike<number> {

--- a/backend/src/post/dto/create-comment.dto.ts
+++ b/backend/src/post/dto/create-comment.dto.ts
@@ -5,8 +5,4 @@ export class CreateCommentDto {
   @IsString()
   @ApiProperty()
   content: string = '';
-
-  @IsNumber()
-  @ApiProperty()
-  postId: number;
 }

--- a/backend/src/post/dto/update-comment.dto.ts
+++ b/backend/src/post/dto/update-comment.dto.ts
@@ -6,8 +6,4 @@ export class UpdateCommenttDto extends PartialType(CreateCommentDto) {
   @IsString()
   @ApiProperty()
   content: string = '';
-
-  @IsNumber()
-  @ApiProperty()
-  postId: number;
 }

--- a/backend/src/post/post.controller.ts
+++ b/backend/src/post/post.controller.ts
@@ -24,57 +24,6 @@ import { FilesInterceptor } from '@nestjs/platform-express';
 @Controller('posts')
 export class PostController {
   constructor(private readonly postService: PostService) {}
-  /* like */
-  @Post('likes/:postId')
-  createLike(@Param('postId') postId: string, @Req() request: Request) {
-    return this.postService.createLike(+postId, request.cookies['publicId']);
-  }
-
-  @Get('likes/:postId')
-  getLikes(@Param('postId') postId: string) {
-    return this.postService.countLikes(+postId);
-  }
-
-  @Delete('likes/:postId')
-  removeLike(@Param('postId') postId: string, @Req() request: Request) {
-    return this.postService.removeLike(+postId, request.cookies['publicId']);
-  }
-
-  /* comment */
-  @Post('comments')
-  createComment(
-    @Body() createCommentDto: CreateCommentDto,
-    @Req() request: Request,
-  ) {
-    return this.postService.createComment(
-      createCommentDto,
-      request.cookies['publicId'],
-    );
-  }
-
-  @Patch('comments/:commentId')
-  updateComment(
-    @Param('commentId') commentId: string,
-    @Body() updateCommentDto: UpdateCommenttDto,
-    @Req() request: Request,
-  ) {
-    return this.postService.updateComment(
-      +commentId,
-      updateCommentDto,
-      request.cookies['publicId'],
-    );
-  }
-
-  @Delete('comments/:commentId')
-  removeComment(
-    @Param('commentId') commentId: string,
-    @Req() request: Request,
-  ) {
-    return this.postService.removeComment(
-      +commentId,
-      request.cookies['publicId'],
-    );
-  }
   /* Post */
   @Post()
   @UseInterceptors(FilesInterceptor('files'))
@@ -89,10 +38,6 @@ export class PostController {
       request.cookies['publicId'],
     );
   }
-  @Get('camps/:campName')
-  findAllPosts(@Param('campName') campName: string) {
-    return this.postService.findAllPostsByCampName(campName);
-  }
 
   @Get(':postId')
   findPost(@Param('postId') postId: string, @Req() request: Request) {
@@ -100,6 +45,11 @@ export class PostController {
       +postId,
       request.cookies['publicId'],
     );
+  }
+
+  @Get('camps/:campName')
+  findAllPosts(@Param('campName') campName: string) {
+    return this.postService.findAllPostsByCampName(campName);
   }
 
   @Patch(':postId')
@@ -118,5 +68,68 @@ export class PostController {
   @Delete(':postId')
   remove(@Param('postId') postId: string) {
     return this.postService.removePost(+postId);
+  }
+
+  /* like */
+  @Get(':postId/likes')
+  getLikes(@Param('postId') postId: string) {
+    return this.postService.countLikes(+postId);
+  }
+
+  @Post(':postId/likes')
+  createLike(@Param('postId') postId: string, @Req() request: Request) {
+    return this.postService.createLike(+postId, request.cookies['publicId']);
+  }
+
+  @Delete(':postId/likes')
+  removeLike(@Param('postId') postId: string, @Req() request: Request) {
+    return this.postService.removeLike(+postId, request.cookies['publicId']);
+  }
+
+  /* comment */
+  @Get(':postId/comments')
+  findComments(@Param('postId') postId: string) {
+    return this.postService.findCommentsByPostId(+postId);
+  }
+
+  @Post(':postId/comments')
+  createComment(
+    @Param('postId') postId: string,
+    @Body() createCommentDto: CreateCommentDto,
+    @Req() request: Request,
+  ) {
+    return this.postService.createComment(
+      +postId,
+      createCommentDto.content,
+      request.cookies['publicId'],
+    );
+  }
+
+  @Patch(':postId/comments/:commentId')
+  updateComment(
+    @Param('postId') postId: string,
+    @Param('commentId') commentId: string,
+    @Body() updateCommentDto: UpdateCommenttDto,
+    @Req() request: Request,
+  ) {
+    return this.postService.updateComment(
+      +postId,
+      +commentId,
+      updateCommentDto.content,
+      request.cookies['publicId'],
+    );
+  }
+
+  @Delete(':postId/comments/:commentId')
+  removeComment(
+    @Param('postId') postId: string,
+    @Param('commentId') commentId: string,
+    @Req() request: Request,
+  ) {
+    return this.postService.removeComment(
+      +postId,
+      +commentId,
+      request.cookies['publicId'],
+    );
   }
 }

--- a/backend/src/post/post.service.ts
+++ b/backend/src/post/post.service.ts
@@ -61,7 +61,7 @@ export class PostService {
       await this.userService.findUserByUserId(post.userId);
     const likeCount = await this.countLikes(postId);
     const commentCount = await this.countComments(postId);
-    const commets = await this.findCommentsByPostId(postId);
+    // const commets = await this.findCommentsByPostId(postId);
     const url = await this.imageService.findImagesByPostId(postId);
     const user = await this.userService.findUserByPublicId(publicId);
     const isLike = await this.findLikeByPostId(postId, user.id);
@@ -71,7 +71,7 @@ export class PostService {
       isLike: isLike,
       likeCount: likeCount,
       commentCount: commentCount,
-      comments: commets,
+      // comments: commets,
       url: url,
     };
   }
@@ -151,22 +151,23 @@ export class PostService {
   }
 
   /* Comment */
-  async createComment(createCommentDto: CreateCommentDto, publicId: string) {
+  async createComment(postId: number, content: string, publicId: string) {
     const user = await this.userService.findUserByPublicId(publicId);
-    return this.commentRepository.create(createCommentDto, user.id);
+    return this.commentRepository.create(postId, content, user.id);
   }
 
   async updateComment(
+    postId: number,
     commentId: number,
-    updateCommentDto: UpdateCommenttDto,
+    content: string,
     publicId: string,
   ) {
     const user = await this.userService.findUserByPublicId(publicId);
     const comment = await this.checkOwnComment(commentId, user.id);
-    return this.commentRepository.update(comment, updateCommentDto);
+    return this.commentRepository.update(comment, content);
   }
 
-  async removeComment(commentId: number, publicId: any) {
+  async removeComment(postId: number, commentId: number, publicId: any) {
     const user = await this.userService.findUserByPublicId(publicId);
     const comment = await this.checkOwnComment(commentId, user.id);
     return this.commentRepository.remove(comment);
@@ -178,7 +179,11 @@ export class PostService {
     return await Promise.all(
       comments.map(async (comment) => {
         const user = await this.userService.findUserByUserId(comment.userId);
-        return { ...comment, publicId: user.publicId };
+        return {
+          ...comment,
+          publicId: user.publicId,
+          profileImage: user.profileImage,
+        };
       }),
     );
   }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -34,12 +34,7 @@ export class UserService {
     const user = await this.findUserByPublicId(publicId);
     const fileName = `${user.publicId}`;
     if (file) {
-      const fileUrl = await this.imageService.uploadFile(
-        file,
-        fileName,
-        -1,
-        user.id,
-      );
+      const fileUrl = await this.imageService.uploadFile(file, fileName, -1);
       user.profileImage = fileUrl;
     }
     if (updateUserDto.chatName) {


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [X] 기능 삭제
- [X] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
- [BGP-8]
- [BGP-38]
- [BGP-124]
- [BGP-32]
- [BGP-127]
- [BGP-117]

### 변경 사항
1. PR 트리거 삭제 -> PR은 git action이 일어나지 않게 수정
2. PUT /camps/:campName으로 배너 이미지 또는 content 수정
3. GET /camps/:campName에서 subscriptrionCount로 구독자수 보냄
4. Image 테이블 변경. post 이미지만 저장하는 용도로만 사용하고 user, camp는 어차피 한 이미지만 올라가니까 Image에 저장 안함.
5. GET posts/:postId/comments 를 추가하고, 상세보기에서 comments를 주는 부분 삭제
6. 코멘트 안에 유저 프로필도 같이 넘겨주기
7. post controller에서 likes, comments 경로 변경
8. camps controller에서 subscriptions 경로 변경

### 동작 확인
<img width="680" alt="스크린샷 2023-11-28 오후 9 35 01" src="https://github.com/boostcampwm2023/web02-fancamp/assets/101859033/6d206c61-7b51-4f32-8676-19f341d893fb">

