### PR TITLE
[BE] 포스트 불러오는 순서 변경, 채팅 페이지네이션 응답 구현

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   Res,
   Req,
+  Query,
 } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { CreateChatDto } from './dto/create-chat.dto';
@@ -34,10 +35,15 @@ export class ChatController {
   // }
 
   @Get(':campName')
-  async findOne(@Param('campName') campName: string, @Req() request: Request) {
+  async findOne(
+    @Param('campName') campName: string,
+    @Query('cursor') cursor: string,
+    @Req() request: Request,
+  ) {
     const result = await this.chatService.getPreviousChats(
       campName,
       request.cookies['publicId'],
+      cursor,
     );
     return result;
   }

--- a/backend/src/chat/chat.repository.ts
+++ b/backend/src/chat/chat.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, LessThan, Repository } from 'typeorm';
 import { Chat } from './entities/chat.entity';
 import { CreateChatDto } from './dto/create-chat.dto';
 
@@ -16,24 +16,66 @@ export class ChatRepository {
     return this.chatRepository.save(createChatDto);
   }
 
+  // async findChatsByUserIdOrMasterId(
+  //   userId: number,
+  //   masterId: number,
+  //   cursor: Date,
+  // ): Promise<Chat[]> {
+  //   if (userId !== masterId) {
+  //     // userId와 masterId가 다르면 camper
+  //     return this.chatRepository.find({
+  //       where: [
+  //         { senderId: userId, masterId: masterId }, // camper의 경우 sender가 userId인 채팅
+  //         { senderId: masterId }, // camper의 경우 sender가 masterId인 채팅
+  //       ],
+  //     });
+  //   } else {
+  //     // userId와 masterId가 같으면 master
+  //     return this.chatRepository.find({
+  //       where: [
+  //         { masterId: masterId }, // master의 경우 masterId가 masterId인 채팅
+  //       ],
+  //     });
+  //   }
+  // }
+
   async findChatsByUserIdOrMasterId(
     userId: number,
     masterId: number,
+    cursor: Date,
   ): Promise<Chat[]> {
     if (userId !== masterId) {
       // userId와 masterId가 다르면 camper
       return this.chatRepository.find({
         where: [
-          { senderId: userId, masterId: masterId }, // camper의 경우 sender가 userId인 채팅
-          { senderId: masterId }, // camper의 경우 sender가 masterId인 채팅
+          {
+            senderId: userId,
+            masterId: masterId,
+            createdAt: LessThan(cursor), // cursor 이후의 채팅만 가져오기
+          },
+          {
+            senderId: masterId,
+            createdAt: LessThan(cursor), // cursor 이후의 채팅만 가져오기
+          },
         ],
+        order: {
+          createdAt: 'DESC', // 내림차순으로 정렬하여 최신 채팅이 먼저 오도록 함
+        },
+        take: 10, // 최대 10개의 결과만 가져오도록 제한
       });
     } else {
       // userId와 masterId가 같으면 master
       return this.chatRepository.find({
         where: [
-          { masterId: masterId }, // master의 경우 masterId가 masterId인 채팅
+          {
+            masterId: masterId,
+            createdAt: LessThan(cursor), // cursor 이후의 채팅만 가져오기
+          },
         ],
+        order: {
+          createdAt: 'DESC', // 내림차순으로 정렬하여 최신 채팅이 먼저 오도록 함
+        },
+        take: 10, // 최대 10개의 결과만 가져오도록 제한
       });
     }
   }

--- a/backend/src/chat/entities/chat.entity.ts
+++ b/backend/src/chat/entities/chat.entity.ts
@@ -11,7 +11,7 @@ export class Chat {
   chatId: number;
 
   @UpdateDateColumn({ name: 'updated _at' })
-  createdAt: string; //TODO: time type으로 바꾸기
+  createdAt: Date; //TODO: time type으로 바꾸기
 
   @Column({ type: 'varchar', nullable: true })
   stringContent: string = '';

--- a/backend/src/http/chat.http
+++ b/backend/src/http/chat.http
@@ -3,7 +3,7 @@
 # @server = http://175.45.194.10:3000
 # @server = http://223.130.146.223:3000
 
-### 메세지 생성
+### 메세지 생성 - 캠퍼
 POST {{server}}/chats
 Content-Type: application/json
 
@@ -15,6 +15,24 @@ Content-Type: application/json
 }
 
 
-### 이전메세지 가져오기?
-GET {{server}}/chats/camp1
+### 메세지 생성 - 마스터
+POST {{server}}/chats
+Content-Type: application/json
 
+{
+    "stringContent": "마스터가 보냅니다~~",
+    "picContent": "",
+    "senderId": 4,
+    "masterId": 4
+}
+
+
+### 이전메세지 가져오기?
+GET {{server}}/chats/master1
+
+### 이전메세지 가져오기 - 페이지  
+GET {{server}}/chats/master1?cursor=2023-11-29T02:36:43.152Z
+
+
+### 이전메세지 가져오기 - 페이지 
+GET {{server}}/chats/master1?cursor=2023-11-22T09:37:57.074Z

--- a/backend/src/post/post.repository.ts
+++ b/backend/src/post/post.repository.ts
@@ -35,7 +35,11 @@ export class PostRepository {
     return this.postRepository.findOneBy({ postId });
   }
   findAllByMasterId(masterId: number) {
-    return this.postRepository.findBy({ userId: masterId });
+    return this.postRepository
+      .createQueryBuilder('post')
+      .where('post.userId = :masterId', { masterId })
+      .orderBy('post.createdAt', 'DESC') // 역순으로 정렬
+      .getMany();
   }
 
   async update(post: Post, updatePostDto: UpdatePostDto) {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -5,4 +5,5 @@ export const ERR_MESSAGE = Object.freeze({
   COMMENT_NOT_FOUND_BY_ID: 'Comment with ID not found',
   NOT_COMMENT_OWNER: 'Not Comment Owner',
   NOT_SUBSCRIBED: 'Not Subscribed',
+  NO_MORE_MESSAGE: 'No More Message',
 } as const);


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [X] 버그 수정

### 관련 이슈
- [BGP-117]
- [BGP-202]

### 변경 사항
1. 채팅 페이지네이션 응답 구현
2. nextCursor는 마지막 채팅의 createdAt
3. 더 불러올 메세지가 없으면 400 에러처리
4. 포스트 불러오는 순서 쿼리 변경

### 동작 확인

```
{
  "cursor": "2023-11-22T09:29:06.999Z",
  "nextCursor": "2023-11-22T09:29:00.746Z",
  "result": [
    {
      "stringContent": "캠퍼1 보냅니다 (닉네임)안녕!",
      "picContent": "",
      "chatId": 30,
      "createdAt": "2023-11-22T09:29:06.807Z",
      "senderId": 1,
      "masterId": 4
    },
    {
      "stringContent": "캠퍼1 보냅니다 (닉네임)안녕!",
      "picContent": "",
      "chatId": 29,
      "createdAt": "2023-11-22T09:29:03.404Z",
      "senderId": 1,
      "masterId": 4
    },
    {
      "stringContent": "캠퍼1 보냅니다 (닉네임)안녕!",
      "picContent": "",
      "chatId": 28,
      "createdAt": "2023-11-22T09:29:00.746Z",
      "senderId": 1,
      "masterId": 4
    }
  ]
}
```

[BGP-117]: https://coli-heo.atlassian.net/browse/BGP-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-202]: https://coli-heo.atlassian.net/browse/BGP-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ