### PR TITLE
[BE] 채팅 메세지 형식 통일

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -40,10 +40,14 @@ export class ChatGateway {
       `캠퍼메세지 - socket.id: ${socket.id} | data: ${JSON.stringify(data)}`,
     );
     const { message, publicId, campName } = data; //TODO: 받아오는것도 DTO로.
-    this.chatService.createFromSocket(message, publicId, campName);
+    const chatWithSender = await this.chatService.createFromSocket(
+      message,
+      publicId,
+      campName,
+    );
     const { roomName, detailRoomName } =
       await this.chatService.getRoomName(campName);
-    socket.to(detailRoomName).emit('message', message);
+    socket.to(detailRoomName).emit('message', chatWithSender);
   }
 
   @SubscribeMessage('masterMessage')
@@ -52,10 +56,14 @@ export class ChatGateway {
       `마스터메세지- socket.id: ${socket.id} | data: ${JSON.stringify(data)}`,
     );
     const { message, publicId, campName } = data; //TODO: 받아오는것도 DTO로.
-    this.chatService.createFromSocket(message, publicId, campName);
+    const chatWithSender = await this.chatService.createFromSocket(
+      message,
+      publicId,
+      campName,
+    );
     const { roomName, detailRoomName } =
       await this.chatService.getRoomName(campName);
-    socket.broadcast.to(roomName).emit('message', message);
+    socket.broadcast.to(roomName).emit('message', chatWithSender);
   }
 
   @SubscribeMessage('camperOut')


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가

### 관련 이슈
- [BGP-183]
- [BGP-202]

### 변경 사항
1. 채팅 DB에서 가져와서 보낼때와, socket에서 emit할때 보내는 형식 통일.
2. 보낼때 채팅 객체에 chatName, publicId, profileImage를 추가해서 보냄.

### 동작 확인
```
"cursor": "2023-11-29T02:36:43.152Z",
"nextCursor": "2023-11-22T09:29:06.999Z",
"result": [
  {
    "stringContent": "캠퍼2 보냅니다 (닉네임)안녕!",
    "picContent": "",
    "chatId": 40,
    "createdAt": "2023-11-22T09:40:20.126Z",
    "senderId": 2,
    "masterId": 4,
    "chatName": "campe2",
    "publicId": "camper2",
    "profileImage": ""
  },
...
```

[BGP-183]: https://coli-heo.atlassian.net/browse/BGP-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-202]: https://coli-heo.atlassian.net/browse/BGP-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ