### PR TITLE
[BE] 최신 포스트 반환 값 변경, 상세보기 로그인 구별, masterOut 관련 event 수정

### DIFF
--- a/backend/src/post/post.service.ts
+++ b/backend/src/post/post.service.ts
@@ -44,19 +44,9 @@ export class PostService {
       };
     }
 
-    const results = await Promise.all(
-      posts.map(async (post) => {
-        const likeCount = await this.countLikes(post.postId);
-        const commentCount = await this.countComments(post.postId);
-        const url = await this.imageService.findImagesByPostId(post.postId);
-        return {
-          ...post,
-          likeCount: likeCount,
-          commentCount: commentCount,
-          url: url,
-        };
-      }),
-    );
+    const results = posts.map((post) => {
+      return post.postId;
+    });
 
     return {
       cursor: cursor,
@@ -98,24 +88,25 @@ export class PostService {
       await this.userService.findUserByUserId(post.userId);
     const likeCount = await this.countLikes(postId);
     const commentCount = await this.countComments(postId);
-    // const commets = await this.findCommentsByPostId(postId);
     const url = await this.imageService.findImagesByPostId(postId);
-    const user = await this.userService.findUserByPublicId(publicId);
-    const isLike = await this.findLikeByPostId(postId, user.id);
+    const isLike = await this.isLikePost(postId, publicId);
     return {
       ...post,
       publicId: writerPublicId,
       isLike: isLike,
       likeCount: likeCount,
       commentCount: commentCount,
-      // comments: commets,
       url: url,
     };
   }
 
-  // findPost(postId: number) {
-  //   return this.postRepository.findOne(postId);
-  // }
+  async isLikePost(postId: number, publicId: string) {
+    if (publicId) {
+      const user = await this.userService.findUserByPublicId(publicId);
+      if (user) return await this.findLikeByPostId(postId, user.id);
+    }
+    return false;
+  }
 
   async findAllPostsByCampName(campName: string) {
     //TODO: 쿠키 분석해서 구독중인지 확인


### PR DESCRIPTION
### PR 타입
- [X] 버그 수정

### 관련 이슈
- [BGP-127]
- [BGP-221]
- [BGP-222]

### 변경 사항
1. GET /posts 로 요청을 보내면 커서로 20개 의 postId만 가져오기
2. 상세보기에서 publicId가 있는지 확인하고 있으면 user 찾고 있으면 그걸로 좋아요 여부 찾기
3. 아니면 isLike는 false
4. masterOut에서 roomName으로 emit하게 변경
5. 중복 방지를 위해 배열로 하던 것을 집합 method로 변경

### 동작 확인


[BGP-127]: https://coli-heo.atlassian.net/browse/BGP-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-221]: https://coli-heo.atlassian.net/browse/BGP-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-222]: https://coli-heo.atlassian.net/browse/BGP-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ