### PR TITLE
[FE] 무한 스크롤, 피드 요청 버그 수정

### DIFF
--- a/frontend/src/hooks/api/useAuthQuery.ts
+++ b/frontend/src/hooks/api/useAuthQuery.ts
@@ -1,0 +1,19 @@
+import { BASE_URL } from '@constants/URLs';
+import { useQuery } from '@tanstack/react-query';
+import useFetch from './useFetch';
+
+export const validateEmailQuery = (email: string) => {
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['email', email],
+    queryFn: () =>
+      useFetch(`${BASE_URL}/auth/users/duplicateEmail`, {
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ email }),
+      }),
+    gcTime: 0,
+    staleTime: 0,
+  });
+
+  return { data, isError, isLoading };
+};

--- a/frontend/src/hooks/api/useCommentQuery.ts
+++ b/frontend/src/hooks/api/useCommentQuery.ts
@@ -24,7 +24,7 @@ export const getCommentsInfiniteQuery = (postId: string) => {
       },
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       initialPageParam: new Date(),
-      gcTime: 0,
+      gcTime: 3000,
       staleTime: 0,
     });
 

--- a/frontend/src/hooks/api/usePostQuery.ts
+++ b/frontend/src/hooks/api/usePostQuery.ts
@@ -17,7 +17,7 @@ export const getPostQuery = (postId: string) => {
         credentials: 'include',
       }),
     gcTime: 0,
-    staleTime: 0,
+    staleTime: 3000,
   });
 
   return { data, isError, isLoading };

--- a/frontend/src/hooks/useInfiniteSlider.ts
+++ b/frontend/src/hooks/useInfiniteSlider.ts
@@ -28,14 +28,10 @@ const useInfiniteSlider = <Item>(items: Item[]) => {
   };
 
   const handleTransitionEnd = () => {
-    if (index === 1) {
+    if (index === 1 || index === 3) {
       setIndex(2);
       setY(-140);
-      setSlidePage(slidePage - 1);
-    } else if (index === 3) {
-      setIndex(2);
-      setY(-140);
-      setSlidePage(slidePage + 1);
+      setSlidePage(index === 1 ? slidePage - 1 : slidePage + 1);
     }
   };
 

--- a/frontend/src/pages/feed/FeedCardTemplate.tsx
+++ b/frontend/src/pages/feed/FeedCardTemplate.tsx
@@ -100,8 +100,8 @@ function FeedCardTemplate({
               key={`comment-${comment.commentId}`}
             />
           ))}
+          <div ref={observerRef} className="h-[0.0625rem]" />
         </ul>
-        <div ref={observerRef} className="h-sm" />
       </div>
       <InputComment
         comment={inputComment}


### PR DESCRIPTION
### PR 타입
- [X] 버그 수정

### 변경 사항
- 무한 스크롤 버그 수정
  기존의 무한 스크롤은 특정 요소가 화면에 보일 때, 요청을 보내도록 합니다. 그러나 가끔 이 요소가 화면에 보이지 않는 버그가 있어 이를 수정했습니다
- 피드 관련 요청을 두번 보내는 버그 수정
  피드 페이지에서 같은 요청을 두번 보내는 버그가 있어, 아주 잠시동안 캐싱을 하는 방식으로 수정했습니다.

