### PR TITLE
fix-fe: 채팅 인피니트 스크롤 버그 임시 해결, useMemo 적용

### DIFF
--- a/frontend/src/components/chat/ChatBoxBody.tsx
+++ b/frontend/src/components/chat/ChatBoxBody.tsx
@@ -1,7 +1,7 @@
 import ChatBoxMessage from './ChatBoxMessage';
 import Spinner from '@components/loading/Spinner';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
-import { useEffect, useRef, Fragment } from 'react';
+import { useEffect, useRef, useMemo, Fragment } from 'react';
 import { Message } from './ChatBox';
 import { getFullDateString } from '@utils/date';
 
@@ -25,6 +25,7 @@ export default function ChatBoxBody({
   isFetching,
 }: Props) {
   const newMessageRef = useRef<HTMLLIElement>(null);
+
   const topMessageRef = useIntersectionObserver((entry, observer) => {
     observer.unobserve(entry.target);
     if (hasNextPage && !isFetching) {
@@ -35,16 +36,19 @@ export default function ChatBoxBody({
   useEffect(() => {
     if (newMessageRef && newMessageRef.current) {
       newMessageRef.current.scrollIntoView();
-      window.scrollTo(0, 0);
     }
   }, [messages]);
 
-  const infiniteMessages: Message[] = infiniteData?.pages
-    ? infiniteData.pages
-        .map((page: any) => page.result)
-        .flat()
-        .reverse()
-    : [];
+  const infiniteMessages: Message[] = useMemo(
+    () =>
+      infiniteData
+        ? infiniteData.pages
+            .map((page: any) => page.result)
+            .flat()
+            .reverse()
+        : [],
+    [infiniteData]
+  );
 
   const dateMap = new Map<string, number>();
   const idSet = new Set<number>();

--- a/frontend/src/hooks/useIntersectionObserver.ts
+++ b/frontend/src/hooks/useIntersectionObserver.ts
@@ -22,7 +22,13 @@ export default function useIntersectionObserver(
         }
       });
     }, options);
-    observer.observe(ref.current);
+
+    // ChatBox에서 fetchNextPage요청이 반복적으로 여러번 되고 있어 임시 해결
+    setTimeout(() => {
+      if (ref.current) {
+        observer.observe(ref.current);
+      }
+    }, 1000);
 
     return () => {
       observer.disconnect();


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 스크롤시 fetch 요청이 여러번 가는 것 setTimeout으로 임시 해결
- 무한스크롤 데이터 평탄화 작업 렌더링마다 계산을 다시하지 않도록 useMemo 적용