### PR TITLE
[BE] api 수정 및 추가

### DIFF
--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -25,7 +25,6 @@ import { FileInterceptor } from '@nestjs/platform-express';
 export class CampController {
   constructor(private readonly campService: CampService) {}
 
-  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.campService.findAll();

--- a/backend/src/camp/camp.controller.ts
+++ b/backend/src/camp/camp.controller.ts
@@ -74,13 +74,9 @@ export class CampController {
     this.campService.subscribe(request.cookies['publicId'], campName);
   }
 
-  // @Patch(':id')
-  // update(@Param('id') id: string, @Body() updateCampDto: UpdateCampDto) {
-  //   return this.campService.update(+id, updateCampDto);
-  // }
-
-  // @Delete(':id')
-  // remove(@Param('id') id: string) {
-  //   return this.campService.remove(+id);
-  // }
+  @UseGuards(AuthGuard)
+  @Delete(':campName/subscriptions')
+  remove(@Param('campName') campName: string, @Req() request: Request) {
+    return this.campService.remove(request.cookies['publicId'], campName);
+  }
 }

--- a/backend/src/camp/camp.service.ts
+++ b/backend/src/camp/camp.service.ts
@@ -40,14 +40,13 @@ export class CampService {
       masterId: masterId,
       isSubscribe: true,
     });
-    // throw new Error('Method not implemented.');
   }
+
   async getSubscriptions(publicId: string) {
     const user = await this.userService.findUserByPublicId(publicId);
-    const camperId = user.id;
-    console.log('campid', camperId);
-    return await this.subscriptionService.findAll(camperId);
+    return await this.subscriptionService.findAll(user.id);
   }
+
   async getSubscription(publicId: string, campName: string) {
     const user = await this.userService.findUserByPublicId(publicId);
     const camperId = user.id;
@@ -71,5 +70,12 @@ export class CampService {
       camp.content = updateCampDto.content;
     }
     return this.campRepository.update(camp);
+  }
+
+  async remove(publicId: string, campName: string) {
+    const user = await this.userService.findUserByPublicId(publicId);
+    const camp = await this.campRepository.findOneByCampName(campName);
+
+    return this.subscriptionService.remove(user.id, camp.masterId);
   }
 }

--- a/backend/src/camp/entities/subscription.entity.ts
+++ b/backend/src/camp/entities/subscription.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
+@Index(['camperId', 'masterId'], { unique: true })
 export class Subscription {
   @PrimaryGeneratedColumn()
   subscriptionId: number;

--- a/backend/src/camp/subscription.repository.ts
+++ b/backend/src/camp/subscription.repository.ts
@@ -13,18 +13,41 @@ export class SubscriptionRepository {
   }
 
   createSubscription(createSubscriptionDto: CreateSubscriptionDto) {
-    console.log(createSubscriptionDto);
-    return this.subscriptionRepository.save(createSubscriptionDto);
+    return this.subscriptionRepository.query(
+      'INSERT INTO `subscription` (camperId, masterId, isSubscribe) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE isSubscribe = VALUES(isSubscribe)',
+      [
+        createSubscriptionDto.camperId,
+        createSubscriptionDto.masterId,
+        createSubscriptionDto.isSubscribe,
+      ],
+    );
   }
 
   findOne(camperId: number, masterId: number) {
-    return this.subscriptionRepository.findOneBy({ camperId, masterId });
+    return this.subscriptionRepository.findOneBy({
+      camperId,
+      masterId,
+      isSubscribe: true,
+    });
   }
+
   findAll(camperId: number) {
-    return this.subscriptionRepository.findBy({ camperId });
+    return this.subscriptionRepository.findBy({ camperId, isSubscribe: true });
   }
 
   count(masterId: number) {
-    return this.subscriptionRepository.count({ where: { masterId } });
+    return this.subscriptionRepository.count({
+      where: { masterId, isSubscribe: true },
+    });
+  }
+
+  remove(camperId: number, masterId: number) {
+    return this.subscriptionRepository
+      .createQueryBuilder()
+      .update(Subscription)
+      .set({ isSubscribe: false })
+      .where('camperId = :camperId', { camperId })
+      .andWhere('masterId = :masterId', { masterId })
+      .execute();
   }
 }

--- a/backend/src/camp/subscription.service.ts
+++ b/backend/src/camp/subscription.service.ts
@@ -40,4 +40,11 @@ export class SubscriptionService {
   async getCount(masterId: number) {
     return this.subscriptionRepository.count(masterId);
   }
+
+  async remove(camperId: number, masterId: number) {
+    if (await this.subscriptionRepository.findOne(camperId, masterId)) {
+      return this.subscriptionRepository.remove(camperId, masterId);
+    }
+    throw new HttpException(ERR_MESSAGE.NOT_SUBSCRIBED, HttpStatus.BAD_REQUEST);
+  }
 }

--- a/backend/src/http/auth.http
+++ b/backend/src/http/auth.http
@@ -8,12 +8,12 @@ POST {{server}}/auth/users
 Content-Type: application/json
 
 {
-    "email" : "master6@fancamp.com",
+    "email" : "camper1@fancamp.com",
     "password": "1234",
-    "chatName": "master6",
-    "publicId": "master6",
+    "chatName": "camper1",
+    "publicId": "camper1",
     "profileImage": "",
-    "isMaster": true
+    "isMaster": false
 }
 
 ### 마스터 로그인 요청~
@@ -46,7 +46,7 @@ POST {{server}}/auth/users/duplicateEmail
 Content-Type: application/json
 
 {
-    "email" : "master10@fancamp.com"
+    "email" : "master2@fancamp.com"
 }
 
 ### publicId 중복 여부 확인
@@ -54,5 +54,8 @@ POST {{server}}/auth/users/duplicatePublicId
 Content-Type: application/json
 
 {
-    "publicId" : "master6"
+    "publicId" : "master2"
 }
+
+### publicId로 프로필 이미지 가져오기
+GET {{server}}/auth/users/profileImage/master1

--- a/backend/src/http/camp.http
+++ b/backend/src/http/camp.http
@@ -21,16 +21,13 @@ GET {{server}}/camps
 GET {{server}}/camps/camp1
 
 ### 구독하기
-POST {{server}}/camps/subscriptions/camp2
-Content-Type: application/json
+POST {{server}}/camps/master1/subscriptions
 
-{
-    "camperId" : "1",
-    "masterId": "5"
-}
-
-### 모든 자신의 구독 가져오기
-GET {{server}}/camps/subscriptions
-
+### 모든 자신의 구독 가져오기  
+GET {{server}}/camps/subscriptions 
+ 
 ###
-GET {{server}}/camps/subscriptions/camp1
+GET {{server}}/camps/master1/subscriptions
+ 
+### 구독 취소
+DELETE {{server}}/camps/master1/subscriptions

--- a/backend/src/http/like.http
+++ b/backend/src/http/like.http
@@ -2,11 +2,11 @@
 @server = http://localhost:3000
 # @server = http://223.130.146.223:3000
 
-### 포스트 id로 좋아요 생성하기 -> 중복처리
-POST {{server}}/posts/28/likes/
+### 포스트 id로 좋아요 생성하기 -> 중복처리 
+POST {{server}}/posts/1/likes/ 
 
-### 포스트 id로 좋아요 지우기  
-DELETE {{server}}/posts/28/likes
+### 포스트 id로 좋아요 지우기   
+DELETE {{server}}/posts/1/likes
 
 ### postId로 좋아요 수 가져오기
-GET {{server}}/posts/28/likes
+GET {{server}}/posts/1/likes

--- a/backend/src/http/post.http
+++ b/backend/src/http/post.http
@@ -21,7 +21,7 @@ GET {{server}}/posts/28
 GET {{server}}/posts/camps/camp1
 
 ### 글 내용 수정
-PATCH {{server}}/posts/7
+PATCH {{server}}/posts/1
 Content-Type: application/json
 
 {

--- a/backend/src/post/post.controller.ts
+++ b/backend/src/post/post.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   Req,
+  UseGuards,
   Put,
   UploadedFiles,
   UseInterceptors,
@@ -20,6 +21,7 @@ import { CreateCommentDto } from './dto/create-comment.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { UpdateCommenttDto } from './dto/update-comment.dto';
 import { FilesInterceptor } from '@nestjs/platform-express';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @ApiTags('posts')
 @Controller('posts')
@@ -31,6 +33,7 @@ export class PostController {
     return this.postService.findAllCampsPosts(cursor);
   }
 
+  @UseGuards(AuthGuard)
   @Post()
   @UseInterceptors(FilesInterceptor('files'))
   create(
@@ -58,6 +61,7 @@ export class PostController {
     return this.postService.findAllPostsByCampName(campName);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':postId')
   updatePost(
     @Param('postId') postId: string,
@@ -71,6 +75,7 @@ export class PostController {
     );
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':postId')
   remove(@Param('postId') postId: string) {
     return this.postService.removePost(+postId);
@@ -82,11 +87,13 @@ export class PostController {
     return this.postService.countLikes(+postId);
   }
 
+  @UseGuards(AuthGuard)
   @Post(':postId/likes')
   createLike(@Param('postId') postId: string, @Req() request: Request) {
     return this.postService.createLike(+postId, request.cookies['publicId']);
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':postId/likes')
   removeLike(@Param('postId') postId: string, @Req() request: Request) {
     return this.postService.removeLike(+postId, request.cookies['publicId']);
@@ -101,6 +108,7 @@ export class PostController {
     return this.postService.findCommentsByPostId(+postId, cursor);
   }
 
+  @UseGuards(AuthGuard)
   @Post(':postId/comments')
   createComment(
     @Param('postId') postId: string,
@@ -114,6 +122,7 @@ export class PostController {
     );
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':postId/comments/:commentId')
   updateComment(
     @Param('postId') postId: string,
@@ -129,6 +138,7 @@ export class PostController {
     );
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':postId/comments/:commentId')
   removeComment(
     @Param('postId') postId: string,

--- a/backend/src/post/post.module.ts
+++ b/backend/src/post/post.module.ts
@@ -13,6 +13,7 @@ import { CommentRepository } from './comment.repository';
 import { ImageModule } from 'src/image/image.module';
 import { NoticeGateway } from 'src/notice/notice.gateway';
 import { NoticeModule } from 'src/notice/notice.module';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { NoticeModule } from 'src/notice/notice.module';
     UserModule,
     ImageModule,
     NoticeModule,
+    AuthModule,
   ],
   controllers: [PostController],
   providers: [

--- a/backend/src/post/post.service.ts
+++ b/backend/src/post/post.service.ts
@@ -160,6 +160,7 @@ export class PostService {
       return this.likeRepository.create(postId, user.id);
     }
   }
+
   async removeLike(postId: number, publicId: string) {
     if (await this.checkPost(postId)) {
       const user = await this.userService.findUserByPublicId(publicId);

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -6,4 +6,5 @@ export const ERR_MESSAGE = Object.freeze({
   NOT_COMMENT_OWNER: 'Not Comment Owner',
   NOT_SUBSCRIBED: 'Not Subscribed',
   NO_MORE_MESSAGE: 'No More Message',
+  USER_NOT_FOUND_BY_ID: 'User with ID not found',
 } as const);


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 관련 이슈
- [BGP-226]
- [BGP-227]
- [BGP-230]

### 변경 사항
1. authguard 조정
    1. 전체 캠프 보는 곳에서  authguard 삭제
    2. 포스트, 댓글, 좋아요 작성&수정&삭제 시 authguard
2. 구독 취소
    1. 구독 취소 시 isDeleted = false; (soft delete)
    2. 구독 취소 후 다시 구독해도 중복으로 레코드가 생기지 않고 isDeleted=true로 변경.
    3. 이미 있는 캠프에서 구독을 안한 상태에서 구독 취소 시 400 에러 발생
3. publicId로 profileImage 얻은 api
    1.  publicId가 존재하면 profileImage 값으로 보냄
    2. publicId로 유저를 못 찾으면 400에 user not found 에러 전송



[BGP-226]: https://coli-heo.atlassian.net/browse/BGP-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-227]: https://coli-heo.atlassian.net/browse/BGP-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BGP-230]: https://coli-heo.atlassian.net/browse/BGP-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ