### PR TITLE
[FE] 채팅 페이지 캠프 상세 정보 밑으로 이동, CSS 수정

### DIFF
--- a/frontend/src/components/chat/ChatBox.tsx
+++ b/frontend/src/components/chat/ChatBox.tsx
@@ -49,7 +49,7 @@ export default function ChatBox() {
 
   return (
     <>
-      <div id="#chatbox" className="relative flex h-[900px] flex-col p-8">
+      <div id="#chatbox" className="relative flex flex-col">
         <ChatBoxNavBar isMaster={isMaster} isMasterOnline={isMasterOnline} />
         <ChatBoxBody
           messages={messages}

--- a/frontend/src/components/chat/ChatBoxBody.tsx
+++ b/frontend/src/components/chat/ChatBoxBody.tsx
@@ -61,7 +61,7 @@ export default function ChatBoxBody({
   });
 
   return (
-    <div className="flex h-[600px] flex-col-reverse overflow-y-scroll border-l border-r">
+    <div className="flex h-[calc(100vh-380px)] flex-col-reverse overflow-y-scroll border border-contour-primary">
       <ul className="flex flex-col gap-4 p-8">
         {isFetchingNextPage && (
           <>

--- a/frontend/src/components/chat/ChatBoxInputBar.tsx
+++ b/frontend/src/components/chat/ChatBoxInputBar.tsx
@@ -55,10 +55,11 @@ export default function ChatBoxInputBar({
     <form onSubmit={handleMessageSubmit} className="flex border">
       <input
         name="inputText"
-        className="w-full bg-contour-primary p-4 display-regular-16"
+        className="w-full p-4 display-regular-16"
         onChange={handleInputTextChange}
         value={inputText}
         placeholder="메세지를 보내보세요! 😁"
+        autoFocus
       />
       <button
         className="w-[5rem] border-l bg-point-yellow p-2 display-regular-14 disabled:bg-text-secondary"

--- a/frontend/src/components/chat/ChatBoxMessage.tsx
+++ b/frontend/src/components/chat/ChatBoxMessage.tsx
@@ -53,7 +53,7 @@ const ChatBoxMessage = forwardRef(function ChatBoxMessage(
               isMyMessage
                 ? 'rounded-br-none bg-point-yellow text-text-primary'
                 : 'rounded-tl-none bg-point-lavender text-text-primary'
-            } rounded-lg p-4 display-regular-16`}
+            } rounded-lg border p-4 display-regular-16`}
           >
             {isMyMessage ? stringContent : chatNameReplacedText}
           </span>

--- a/frontend/src/components/chat/ChatBoxNavBar.tsx
+++ b/frontend/src/components/chat/ChatBoxNavBar.tsx
@@ -1,6 +1,4 @@
 import { useParams } from 'react-router';
-import LeftArrowIcon from '../../assets/icons/leftArrowIcon.svg?react';
-import { Link } from 'react-router-dom';
 
 interface Props {
   isMaster: boolean;
@@ -11,19 +9,8 @@ export default function ChatBoxNavBar({ isMaster, isMasterOnline }: Props) {
   const { campId: campName } = useParams();
 
   return (
-    <div className="border-b-none flex items-center gap-4 border bg-yellow p-4">
-      <Link to={'..'} aria-label="go back">
-        <LeftArrowIcon width={40} height={40} />
-      </Link>
-      <div className="overflow-hidden rounded-full border-md">
-        <img
-          width="72"
-          height="72"
-          src="https://picsum.photos/72/72"
-          alt="placeholder"
-        />
-      </div>
-      <div className="flex flex-col gap-2">
+    <div className="flex items-center gap-4 p-4">
+      <div className="flex items-center gap-2">
         <span className="display-regular-20">{campName}</span>
         <span className="display-regular-14">
           {isMaster

--- a/frontend/src/components/chat/ChatBoxToast.tsx
+++ b/frontend/src/components/chat/ChatBoxToast.tsx
@@ -16,7 +16,7 @@ export default function ChatBoxToast({ children, duration }: Props) {
     <>
       {isOpen &&
         createPortal(
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-default rounded-lg bg-logo-green p-4">
+          <div className="absolute left-1/2 top-1/3 -translate-x-1/2 -translate-y-1/2 cursor-default border bg-logo-green p-4">
             <span className="text-white display-regular-16">{children}</span>
           </div>,
           chatBox

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -3,16 +3,19 @@ import SubscribedMenu from '@components/menu/SubscribedMenu';
 import { Outlet, useLocation } from 'react-router-dom';
 
 export default function Layout() {
-  const location = useLocation();
+  const { pathname } = useLocation();
+  const fixScroll = 'h-screen overflow-y-hidden';
 
   return (
     <div className="relative flex w-full justify-between">
       <SideMenu />
-      <main className="min-w-[48rem] flex-1">
+      <main
+        className={`min-w-[48rem] flex-1 ${
+          pathname.endsWith('chat') ? fixScroll : ''
+        }`}
+      >
         <div
-          className={`content ${
-            location.pathname !== '/feed' ? 'py-2xl' : 'px-2xl'
-          }`}
+          className={`content ${pathname !== '/feed' ? 'py-2xl' : 'px-2xl'}`}
         >
           <Outlet />
         </div>

--- a/frontend/src/components/menu/SubscribeMenuButton.tsx
+++ b/frontend/src/components/menu/SubscribeMenuButton.tsx
@@ -34,12 +34,10 @@ function SubscribeMenuButton({
             >
               {text}
             </span>
-            {hasPostNotice && (
-              <span className="display-regular-12 animate-bounce">🔵</span>
-            )}
-            {hasChatNotice && (
-              <span className="display-regular-12 animate-bounce">🟡</span>
-            )}
+            <div className="display-regular-12 animate-bounce">
+              {hasPostNotice && <span>🔵</span>}
+              {hasChatNotice && <span>🟡</span>}
+            </div>
           </div>
         </>
       )}

--- a/frontend/src/constants/sideMenu.tsx
+++ b/frontend/src/constants/sideMenu.tsx
@@ -46,12 +46,12 @@ export const MASTER_MENU = [
 
 export const DOC_MENU = [
   {
-    to: 'https://www.naver.com',
+    to: 'https://github.com/boostcampwm2023/web02-fancamp/wiki',
     text: '개발 문서',
     icon: <NotionIcon width={28} />,
   },
   {
-    to: 'https://www.naver.com',
+    to: 'https://github.com/boostcampwm2023/web02-fancamp',
     text: '깃허브',
     icon: <GithubIcon width={28} />,
   },

--- a/frontend/src/pages/auth/signin/SigninForm.tsx
+++ b/frontend/src/pages/auth/signin/SigninForm.tsx
@@ -59,6 +59,7 @@ export default function SigninForm({
             placeholder="fancamp@naver.com"
             errorMessage={!isEmailOk ? AUTH_CONSTANTS.signin.error.email : ''}
             onBlur={handleBlurEmail}
+            autoFocus
           />
           <Input
             label="비밀번호"

--- a/frontend/src/pages/auth/signup/SignupForm.tsx
+++ b/frontend/src/pages/auth/signup/SignupForm.tsx
@@ -122,6 +122,7 @@ export default function SignupForm({
                     : ''
               }
               onBlur={handleBlurEmail}
+              autoFocus
             />
           ) : signupStatus === 'password' ? (
             <div className="flex flex-col gap-md">
@@ -134,7 +135,8 @@ export default function SignupForm({
                   !isPasswordOk ? AUTH_CONSTANTS.signup.error.password : ''
                 }
                 onBlur={handleBlurPassword}
-              />{' '}
+                autoFocus
+              />
               <Input
                 label="비밀번호 확인"
                 type="password"

--- a/frontend/src/route/router.tsx
+++ b/frontend/src/route/router.tsx
@@ -10,17 +10,17 @@ import UserProfileEditPage from '@pages/user/edit/profile/UserProfileEditPage';
 import UserPasswordEditPage from '@pages/user/edit/password/UserPasswordEditPage';
 import UserPage from '@pages/user/UserPage';
 import CampProfileEditPage from '@pages/camps/edit/CampProfileEditPage';
-import HomePage from '../pages/home/HomePage';
-import SearchPage from '../pages/search/SearchPage';
-import ExplorePage from '../pages/explore/ExplorePage';
-import SignupPage from '../pages/auth/signup/SignupPage';
-import ChatPage from '../pages/camps/chat/ChatPage';
-import PostPage from '../pages/camps/post/PostPage';
-import CampPage from '../pages/camps/CampPage';
-import ErrorPage from '../pages/error/ErrorPage';
+import ErrorPage from '@pages/error/ErrorPage';
+import SigninPage from '@pages/auth/signin/SigninPage';
+import SignupPage from '@pages/auth/signup/SignupPage';
+import HomePage from '@pages/home/HomePage';
+import SearchPage from '@pages/search/SearchPage';
+import ExplorePage from '@pages/explore/ExplorePage';
 import AuthProtectedRoute from './AuthProtectedRoute';
-import SubscriptionsPage from '../pages/subscriptions/SubscriptionsPage';
-import SigninPage from '../pages/auth/signin/SigninPage';
+import SubscriptionsPage from '@pages/subscriptions/SubscriptionsPage';
+import CampPage from '@pages/camps/CampPage';
+import PostPage from '@pages/camps/post/PostPage';
+import ChatPage from '@pages/camps/chat/ChatPage';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -35,11 +35,11 @@ const router = createBrowserRouter(
         <Route path="explore" element={<ExplorePage />} />
         <Route path="feed" element={<FeedPage />} />
         <Route element={<AuthProtectedRoute />}>
-          <Route path="camps/:campId/chat" element={<ChatPage />} />
           <Route path="subscriptions" element={<SubscriptionsPage />} />
           <Route path="camps" element={<CampPage />}>
             <Route path=":campId">
               <Route path="post" element={<PostPage />} />
+              <Route path="chat" element={<ChatPage />} />
             </Route>
           </Route>
           <Route path="camps/edit" element={<CampProfileEditPage />} />


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- [chore-fe: ChatBox 캠프 페이지 내에서 표시 되도록 수정](https://github.com/boostcampwm2023/web02-fancamp/commit/1cfe455c6e0a116f8007a73423c1749a5b9eff17) 
   - 라우팅 수정
   - CSS 디자인 포스트 페이지에 맞춰 수정
   
![0](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/974eec64-8377-4651-ac7e-3682eed2c72e)

- [구독 알림 묶어서 뜨도록 수정](https://github.com/boostcampwm2023/web02-fancamp/commit/e162d877898c2e6162f1f843ade92d1b05c4e4ee)
![1](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/090ff516-76ef-4346-8af1-4cafd98b905c)
![2](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/e7ad3e86-a626-45ba-986e-7e316d6fc176)


- [chore-fe: 로그인, 회원가입 페이지 input autofocus](https://github.com/boostcampwm2023/web02-fancamp/commit/065dc875b43e0f9fb4ee6bcd17d1b7557a6d4be8) 
    - 로그인, 회원가입시에 입력바에 autofocus 어트리뷰트를 추가해 사용자가
한번 덜 클릭해도 되도록 수정

