### PR TITLE
[FE] 이미지 사이즈 최적화

### DIFF
--- a/frontend/src/components/card/CommentCard.tsx
+++ b/frontend/src/components/card/CommentCard.tsx
@@ -3,6 +3,7 @@ import Text from '@components/ui/Text';
 import { Comment } from '@type/api/comment';
 import { formatDate } from '@utils/date';
 import DeleteIcon from '@assets/icons/deleteIcon.svg?react';
+import { optimizedImageURL } from '@utils/imageURL';
 
 interface CommentProps {
   comment: Comment;
@@ -25,7 +26,7 @@ function CommentCard({ comment, isMine, deleteComment }: CommentProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-md">
           <ProfileImage
-            src={profileImage}
+            src={optimizedImageURL(profileImage, 'profile-small')}
             width={24}
             height={24}
             className="rounded-full"

--- a/frontend/src/components/card/PostCard.tsx
+++ b/frontend/src/components/card/PostCard.tsx
@@ -1,5 +1,6 @@
 import Image from '@components/ui/Image';
 import Text from '@components/ui/Text';
+import { optimizedImageURL } from '@utils/imageURL';
 
 interface PostCardProps {
   imageSrc: string;
@@ -39,7 +40,11 @@ function PostCard({
       onClick={() => handleOnClick(postId)}
     >
       {imageSrc ? (
-        <Image src={imageSrc} className={cardImageClassName} alt="" />
+        <Image
+          src={optimizedImageURL(imageSrc, 'post-medium')}
+          className={cardImageClassName}
+          alt={`${postId}`}
+        />
       ) : (
         <div className={cardTextClassName}>
           <Text color="text-secondary">{content}</Text>

--- a/frontend/src/components/card/PostConentCard.tsx
+++ b/frontend/src/components/card/PostConentCard.tsx
@@ -4,6 +4,7 @@ import ProfileImage from '@components/profile/ProfileImage';
 import Text from '@components/ui/Text';
 import useAuth from '@hooks/useAuth';
 import { Link } from 'react-router-dom';
+import { optimizedImageURL } from '@utils/imageURL';
 
 interface PostConentCardProps {
   profileImage: string;
@@ -34,10 +35,11 @@ function PostConentCard({
         <Link to={`/camps/${campName}/post`}>
           <div className="flex items-center gap-sm">
             <ProfileImage
-              src={profileImage}
+              src={optimizedImageURL(profileImage, 'profile-small')}
               width={32}
               height={32}
               className="rounded-full"
+              alt={`${campName}'s profile`}
             />
             <Text>{campName}</Text>
           </div>

--- a/frontend/src/components/chat/ChatBoxMessage.tsx
+++ b/frontend/src/components/chat/ChatBoxMessage.tsx
@@ -1,6 +1,7 @@
 import ProfileImage from '@components/profile/ProfileImage';
 import useAuth from '@hooks/useAuth';
 import { getLocaleString } from '@utils/date';
+import { optimizedImageURL } from '@utils/imageURL';
 import { ForwardedRef, forwardRef } from 'react';
 
 interface Props {
@@ -28,7 +29,7 @@ const ChatBoxMessage = forwardRef(function ChatBoxMessage(
       {!isMyMessage && (
         <div className="flex items-center">
           <ProfileImage
-            src={profileImage}
+            src={optimizedImageURL(profileImage, 'profile-small')}
             width="60"
             height="60"
             className="rounded-full"

--- a/frontend/src/components/slider/MediaSlider.tsx
+++ b/frontend/src/components/slider/MediaSlider.tsx
@@ -7,6 +7,7 @@ import LeftArrowIcon from '@assets/icons/leftArrowIcon.svg?react';
 import RightArrowIcon from '@assets/icons/rightArrowIcon.svg?react';
 import { PostFile } from '@type/api/post';
 import { checkFileType } from '@utils/file';
+import { optimizedImageURL } from '@utils/imageURL';
 
 interface ImageSliderProps {
   width?: number;
@@ -54,8 +55,12 @@ function MediaSlider({ width = 37.5, medias }: ImageSliderProps) {
                 style={{ width: `${width}rem` }}
               >
                 <Image
-                  src={media.fileUrl}
+                  src={optimizedImageURL(media.fileUrl, 'post-large')}
                   className="relative h-full w-full object-contain center"
+                  loading={`${
+                    i === 0 || imageIndex + 1 === i ? 'eager' : 'lazy'
+                  }`}
+                  alt={`media image ${i}`}
                 />
               </div>
             );

--- a/frontend/src/components/ui/Image.tsx
+++ b/frontend/src/components/ui/Image.tsx
@@ -20,7 +20,6 @@ function Image(props: ImageProps) {
       }
       className={`opacity-0 ${className || ''}`}
       onLoad={handleImageLoaded}
-      alt=""
       {...imageProps}
     />
   );

--- a/frontend/src/pages/camps/CampInfo.tsx
+++ b/frontend/src/pages/camps/CampInfo.tsx
@@ -11,6 +11,7 @@ import useSubscriptionQuery, {
   subscribeMutation,
   unsubscribeMutation,
 } from '@hooks/api/useSubscriptionQuery';
+import { optimizedImageURL } from '@utils/imageURL';
 
 function CampInfo() {
   const { campId } = useParams();
@@ -46,8 +47,9 @@ function CampInfo() {
     <div className="relative flex h-[16rem] flex-col justify-end">
       <div className="absolute top-[0] h-[16rem] w-full">
         <Image
-          src={camp.bannerImage || ''}
+          src={optimizedImageURL(camp.bannerImage, 'banner-medium')}
           className="absolute top-[0] z-0 h-full w-full object-cover"
+          alt={`${campId}'s banner`}
         />
         <div
           className="absolute top-[0] z-10 h-full w-full"
@@ -58,7 +60,11 @@ function CampInfo() {
         />
       </div>
       <div className="relative z-20 flex w-full items-center gap-xl  p-xl">
-        <ProfileImage src={profileImage} className="rounded-full" />
+        <ProfileImage
+          src={optimizedImageURL(profileImage, 'profile-medium')}
+          className="rounded-full"
+          alt={`${campId}'s profile`}
+        />
         <div className="flex flex-1 items-center justify-between">
           <div className="flex flex-col justify-evenly gap-md">
             <Text size={20} color="surface-primary">

--- a/frontend/src/pages/explore/ExplorePage.tsx
+++ b/frontend/src/pages/explore/ExplorePage.tsx
@@ -9,6 +9,7 @@ import { Camp } from '@type/api/camp';
 import useIntersectionObserver from '@hooks/useObserver';
 import ProfileImage from '@components/profile/ProfileImage';
 import SearchInputLogic from './SearchInputLogic';
+import { optimizedImageURL } from '@utils/imageURL';
 
 interface CampWithProfile extends Camp {
   masterProfileImage: string;
@@ -72,20 +73,22 @@ function ExplorePageLogic() {
 
 function ExploreCampCard({ camp }: { camp: CampWithProfile }) {
   const { campName, bannerImage, content, masterProfileImage } = camp;
+
   return (
     <Link to={`/camps/${campName}/post`} key={`camp-card-${campName}`}>
       <Card className="w-full border-sm border-text-primary">
         <div className="relative">
           <Image
-            src={bannerImage ? `${bannerImage}?${new Date()}` : ''}
+            src={optimizedImageURL(bannerImage, 'banner-small')}
             className="aspect-[4/3] w-full object-cover"
+            alt={`${campName}'s banner`}
           />
         </div>
         <div className="relative flex flex-col items-center gap-md px-md py-md">
           <div className="flex items-center gap-sm">
             {masterProfileImage && (
               <ProfileImage
-                src={masterProfileImage}
+                src={optimizedImageURL(masterProfileImage, 'profile-small')}
                 className="w-lg rounded-full"
               />
             )}

--- a/frontend/src/pages/explore/SearchInputTemplate.tsx
+++ b/frontend/src/pages/explore/SearchInputTemplate.tsx
@@ -1,6 +1,7 @@
 import SearchInput from '@components/input/SearchInput';
 import Image from '@components/ui/Image';
 import Text from '@components/ui/Text';
+import { optimizedImageURL } from '@utils/imageURL';
 import { Link } from 'react-router-dom';
 
 function SearchInputTemplate({ camps, keyword, setKeyword }: any) {
@@ -22,7 +23,7 @@ function SearchInputTemplate({ camps, keyword, setKeyword }: any) {
             <Link to={`/camps/${campName}/post`} key={`camp-card-${campName}`}>
               <div className="relative flex h-[3.5rem] w-full items-center gap-md bg-surface-primary">
                 <Image
-                  src={masterProfileImage}
+                  src={optimizedImageURL(masterProfileImage, 'profile-small')}
                   className="aspect-square h-full"
                 />
                 <Text

--- a/frontend/src/pages/subscriptions/SubscriptionsPage.tsx
+++ b/frontend/src/pages/subscriptions/SubscriptionsPage.tsx
@@ -3,6 +3,7 @@
 import ProfileImage from '@components/profile/ProfileImage';
 import useSubscriptionQuery from '@hooks/api/useSubscriptionQuery';
 import useAuth from '@hooks/useAuth';
+import { optimizedImageURL } from '@utils/imageURL';
 import { Link } from 'react-router-dom';
 
 export default function SubscriptionsPage() {
@@ -23,7 +24,7 @@ export default function SubscriptionsPage() {
               className="flex flex-col items-center gap-2"
             >
               <ProfileImage
-                src={masterProfileImage}
+                src={optimizedImageURL(masterProfileImage, 'profile-medium')}
                 alt={campName}
                 className="rounded-full"
               />

--- a/frontend/src/utils/imageURL.ts
+++ b/frontend/src/utils/imageURL.ts
@@ -1,0 +1,36 @@
+type ImageType =
+  | 'banner-small'
+  | 'banner-medium'
+  | 'post-large'
+  | 'post-medium'
+  | 'profile-small'
+  | 'profile-medium';
+
+const IMAGE_SIZES = {
+  'banner-small': [320, 240],
+  'banner-medium': [1400, 500],
+  'post-medium': [320, 320],
+  'post-large': [1200, 1000],
+  'profile-small': [80, 80],
+  'profile-medium': [200, 200],
+};
+
+const IMAGE_OPTIMIZER_URL = 'https://ocju9rrf1834.edge.naverncp.com/tlPgesmTAV';
+
+export function optimizedImageURL(urlString: string, type: ImageType): string {
+  if (!urlString) {
+    return '';
+  }
+  if (!type) {
+    return urlString;
+  }
+
+  const url = new URL(urlString);
+  const newHostname = IMAGE_OPTIMIZER_URL;
+  const pathName = url.pathname.replace('/fancamp-images/', '/');
+
+  const [width, height] = IMAGE_SIZES[type];
+  const searchPath = `?type=f&w=${width}&h=${height}`;
+  const newURL = new URL(newHostname + pathName + searchPath);
+  return newURL.toString();
+}


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 현재 서버로 받는 이미지 URL이 도메인 네임까지 포함되어 URL 주소를 바꾸는 함수를 만듬
- 각 렌더링 되는 이미지 사이즈의 2배인 이미지를 받음

### 동작 확인

#### 메인 페이지 이미지 사이즈 최적화 적용 전
![explorePage - 이미지 전](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/89e0af21-a65a-481c-baa4-90ecf5897140)

전체 이미지 파일 크기 10.3 MB
전체 로드 1.30초


#### 메인 페이지 이미지 사이즈 최적화 적용 후
![explorePage - 이미지 후](https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/732d3d3a-d665-48aa-bf0d-0c3c705b6049)

전체 이미지 파일 크기 1.0 MB
전체로드 0.43초

전체 이미지 파일 크기 약 1/10로 감소
전체 로드 시간 33%까지 감소


### 동영상 비교

#### 이미지 최적화 적용 전

https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/640d5f8f-2198-4493-8db9-c5c99e009ccd



#### 이미지 최적화 적용 후


https://github.com/boostcampwm2023/web02-fancamp/assets/54917836/05b851cb-bbb1-43af-ad49-b312a7062f7e




